### PR TITLE
FS add append entry and new test

### DIFF
--- a/src/open_viii/archive/CMakeLists.txt
+++ b/src/open_viii/archive/CMakeLists.txt
@@ -3,4 +3,3 @@ target_link_libraries(${PROJECT_NAME}_VIIIArchive
         INTERFACE ${PROJECT_NAME}_VIIICompression
         INTERFACE ToolsLibrary_tl
         )
-add_subdirectory(test)

--- a/ut/compression.cpp
+++ b/ut/compression.cpp
@@ -19,7 +19,6 @@ private:
     std::numeric_limits<std::make_unsigned_t<T>>::min(),
     std::numeric_limits<std::make_unsigned_t<T>>::max()
   };
-
 public:
   auto
     operator()([[maybe_unused]] const T &unused) const


### PR DESCRIPTION
Partial implementation of writing FS. This allows appending entries. I originally had to write this code for the FS tests. So I just made it into a set of free functions in FS.hpp. And removed some of the code from FS.cpp test project.

related https://github.com/Sebanisu/OpenVIII_CPP_WIP/issues/21