### PR TITLE
Add append functions to fi file data and fl, much like the ones in fs

### DIFF
--- a/src/open_viii/Concepts.hpp
+++ b/src/open_viii/Concepts.hpp
@@ -13,6 +13,7 @@
 #ifndef VIIIARCHIVE_CONCEPTS_HPP
 #define VIIIARCHIVE_CONCEPTS_HPP
 #include "CompressionTypeT.hpp"
+#include "tl/concepts.hpp"
 #include <concepts>
 #include <cstdint>
 #include <string_view>
@@ -156,5 +157,18 @@ concept Foreach_Archive_Lambda =
 //      std::initializer_list<std::string_view> &filename, lambdaT lambda) {
 //         a.execute_with_nested({}, filename, lambda);
 //       });
+
+/**
+ * concepts used by FS
+ */
+
+/**
+ * @tparam T Accept things like std::string or std::ostream
+ */
+template<typename T>
+concept is_insertable_or_ostream =
+  tl::concepts::is_contiguous_with_insert<
+    T> || std::is_base_of_v<std::ostream, std::decay_t<T>>;
+
 }// namespace open_viii
 #endif// VIIIARCHIVE_CONCEPTS_HPP

--- a/src/open_viii/archive/FI.hpp
+++ b/src/open_viii/archive/FI.hpp
@@ -13,8 +13,10 @@
 #ifndef VIIIARCHIVE_FI_HPP
 #define VIIIARCHIVE_FI_HPP
 #include "open_viii/CompressionTypeT.hpp"
+#include "open_viii/Concepts.hpp"
 #include "open_viii/tools/Tools.hpp"
 #include "tl/read.hpp"
+#include "tl/write.hpp"
 #include <algorithm>
 #include <array>
 #include <cstring>
@@ -212,6 +214,19 @@ public:
   }
 };
 static_assert(sizeof(FI) == FI::SIZE);
+
+/**
+ *
+ * @tparam T type of output buffer.
+ * @param output buffer to write to.
+ * @param in_fi incoming FI it's just grabbing the compression type from it.
+ */
+template<is_insertable_or_ostream T>
+static void
+  append_entry(T &output, const FI in_fi)
+{
+  tl::write::append(output, in_fi);
+}
 }// namespace open_viii::archive
 namespace std {
 /**
@@ -219,7 +234,8 @@ namespace std {
  * @note required to structured binding support
  */
 template<>
-struct [[maybe_unused]] tuple_size<open_viii::archive::FI> : std::integral_constant<size_t, 3>
+struct [[maybe_unused]] tuple_size<open_viii::archive::FI>
+  : std::integral_constant<size_t, 3>
 {
 };
 /**

--- a/src/open_viii/archive/FL.hpp
+++ b/src/open_viii/archive/FL.hpp
@@ -16,6 +16,7 @@
 #include "tl/input.hpp"
 #include "tl/read.hpp"
 #include "tl/string.hpp"
+#include "tl/write.hpp"
 #include <cassert>
 #include <filesystem>
 #include <fstream>
@@ -302,6 +303,38 @@ template<typename T>
   }
   return get_entry(data, needle, offset, size, count);
 }
-
 }// namespace open_viii::archive::fl
+namespace open_viii::archive {
+
+/**
+ * Append FL path to buffer.
+ * @tparam T type of output buffer.
+ * @param path being wrote.
+ * @note path is prepended with c:\ and appended with \r\n.
+ */
+template<is_insertable_or_ostream T>
+static void
+  append_entry(T &output, const std::filesystem::path &path)
+{
+  using namespace std::string_literals;
+  std::string string = "c:\\"s + path.string() + "\r\n"s;
+  tl::string::undo_replace_slashes(string);
+  tl::write::append(output, string);
+}
+///**
+// * Append FL path to buffer.
+// * @tparam T type of output buffer.
+// * @param path being wrote.
+// * @note path is prepended with c:\ and appended with \r\n.
+// */
+//template<is_insertable_or_ostream T>
+//static void
+//  append_entry(T &output, const std::string_view &path)
+//{
+//  using namespace std::string_literals;
+//  std::string string = "c:\\"s + std::string(path) + "\r\n"s;
+//  tl::string::undo_replace_slashes(string);
+//  tl::write::append(output, string);
+//}
+}// namespace open_viii::archive
 #endif// !VIIIARCHIVE_FL_HPP

--- a/src/open_viii/archive/FS.hpp
+++ b/src/open_viii/archive/FS.hpp
@@ -152,6 +152,7 @@ template<
   }
   return get_entry<outputT>(tl::read::input(data, true), fi, offset);
 }
+// todo I need a version for a std::ostream and a version for a std::vector;
 static void
   append(std::vector<char> &output, const std::span<const char> &input)
 {
@@ -160,6 +161,7 @@ static void
                 std::ranges::end(input));
 }
 template<typename inputT>
+// todo I need a version for a std::ostream and a version for a std::vector;
 requires(std::is_trivially_copyable_v<inputT> && !requires(inputT t) {
   // prevents things that std::span could take from going here
   std::span<const char>(t);
@@ -169,6 +171,7 @@ requires(std::is_trivially_copyable_v<inputT> && !requires(inputT t) {
   std::memcpy(std::data(input_as_bytes), &input, sizeof(inputT));
   append(output, input_as_bytes);
 }
+// todo I need a version for a std::ostream and a version for a std::vector;
 static void
   append_lzss(std::vector<char> &output, const std::span<const char> &input)
 {
@@ -176,6 +179,7 @@ static void
   append(output, static_cast<uint32_t>(std::ranges::size(new_comp_data)));
   append(output, new_comp_data);
 }
+// todo I need a version for a std::ostream and a version for a std::vector;
 static void
   append_l4z(std::vector<char> &output, const std::span<const char> &input)
 {

--- a/src/open_viii/archive/FS.hpp
+++ b/src/open_viii/archive/FS.hpp
@@ -33,20 +33,6 @@ namespace open_viii::archive::FS {
  * @see http://wiki.ffrtt.ru/index.php?title=FF8/PC_Media#.fs_.28File_Source.29
  */
 
-namespace concepts {
-  /**
-   * concepts used by FS
-   */
-
-  /**
-   * @tparam T Accept things like std::string or std::ostream
-   */
-  template<typename T>
-  concept is_insertable_or_ostream =
-    tl::concepts::is_contiguous_with_insert<
-      T> || std::is_base_of_v<std::ostream, std::decay_t<T>>;
-}// namespace concepts
-
 /**
  * Extension
  */
@@ -180,6 +166,8 @@ template<
   }
   return get_entry<outputT>(tl::read::input(data, true), fi, offset);
 }
+}// namespace open_viii::archive::FS
+namespace open_viii::archive {
 
 /**
  * Append lzss compressed entry
@@ -187,7 +175,7 @@ template<
  * @param output buffer to write to.
  * @param input buffer to read from.
  */
-template<concepts::is_insertable_or_ostream T>
+template<is_insertable_or_ostream T>
 static void
   append_lzss(T &output, const std::span<const char> &input)
 {
@@ -203,7 +191,7 @@ static void
  * @param output buffer to write to.
  * @param input buffer to read from.
  */
-template<concepts::is_insertable_or_ostream T>
+template<is_insertable_or_ostream T>
 static void
   append_l4z(T &output, const std::span<const char> &input)
 {
@@ -227,7 +215,7 @@ static void
  * @param compression_type desired compression value: none, lzss, lz4
  * @return return FI like data.
  */
-template<concepts::is_insertable_or_ostream T, FI_Like fiT = FI>
+template<is_insertable_or_ostream T, FI_Like fiT = FI>
 static fiT
   append_entry(T &                         output,
                const std::span<const char> input,
@@ -268,13 +256,11 @@ static fiT
  * @param in_fi incoming FI it's just grabbing the compression type from it.
  * @return return FI like data.
  */
-template<FI_Like                            in_fiT  = FI,
-         FI_Like                            out_fiT = FI,
-         concepts::is_insertable_or_ostream T>
+template<FI_Like in_fiT = FI, FI_Like out_fiT = FI, is_insertable_or_ostream T>
 static out_fiT
   append_entry(T &output, const std::span<const char> input, const in_fiT in_fi)
 {
   return append_entry(output, input, in_fi.compression_type());
 }
-}// namespace open_viii::archive::FS
+}// namespace open_viii::archive
 #endif// !VIIIARCHIVE_FS_HPP

--- a/src/open_viii/archive/FileData.hpp
+++ b/src/open_viii/archive/FileData.hpp
@@ -40,22 +40,24 @@ private:
   std::uint32_t m_size{};
 
 public:
-  constexpr FileData()       = default;
-/**
- * Piecemeal constructor
- * @param filename path to file
- * @param offset path to
- * @param size
- */
-  [[maybe_unused]] FileData(const std::string_view filename,
-                            const unsigned long    offset,
-                            unsigned int           size)
-    : m_filename(filename), m_offset(offset), m_size(size)
+  constexpr FileData() = default;
+  /**
+   * Piecemeal constructor
+   * @param filename path to file
+   * @param offset path to
+   * @param size
+   */
+  [[maybe_unused]] FileData(std::string         filename,
+                            const unsigned long offset,
+                            unsigned int        size)
+    : m_filename(tl::string::replace_slashes(std::move(filename))),
+      m_offset(offset),
+      m_size(size)
   {
     tl::string::replace_slashes(m_filename);
   }
   [[maybe_unused]] FileData(const unsigned long offset, unsigned int size)
-    : FileData(std::string_view(), offset, size)
+    : FileData(std::string(), offset, size)
   {}
   [[nodiscard]] bool
     empty() const noexcept
@@ -72,6 +74,12 @@ public:
     : FileData(input, input.output<std::uint32_t>())
   {}
   explicit FileData(std::istream &fp) : FileData(tl::read::input(&fp, true)) {}
+  explicit FileData(std::span<const char> *const fp)
+    : FileData(tl::read::input(fp, true))
+  {}
+  explicit FileData(std::span<const char> fp)
+    : FileData(tl::read::input(&fp, true))
+  {}
   template<FI_Like fiT>
   requires(!std::is_same_v<fiT, FileData>) constexpr explicit FileData(
     const fiT &fi)
@@ -85,9 +93,9 @@ public:
     }
   }
   template<FI_Like fiT>
-  requires(!std::is_same_v<fiT, FileData>) constexpr explicit FileData(
-    const std::string &filename, const fiT &fi)
-    : m_filename(filename),
+  requires(!std::is_same_v<fiT, FileData>) explicit FileData(
+    std::string filename, const fiT &fi)
+    : m_filename(tl::string::replace_slashes(std::move(filename))),
       m_offset{ static_cast<decltype(m_offset)>(fi.offset()) },
       m_size{ static_cast<decltype(m_size)>(fi.uncompressed_size()) }
   {
@@ -146,23 +154,28 @@ public:
    * gets path as a std::string_view
    */
   [[maybe_unused]] [[nodiscard]] auto
-    get_path_string() const
+    get_path_string_view() const
   {
     return std::string_view(m_filename);
   }
-  //  [[maybe_unused]] [[nodiscard]] auto get_tuple() const
-  //  {
-  //    return std::make_tuple(get_path_string(), offset(), size());
-  //  }
+  /**
+   * gets path as a std::string
+   */
+  [[maybe_unused]] [[nodiscard]] auto
+    get_path_string() const
+  {
+    return m_filename;
+  }
+
   /**
    * gets member variables
    * @note required to structured binding support
    */
   template<std::size_t I>
-  requires(I < 3) [[nodiscard]] const auto &get() const noexcept
+  requires(I < 3) [[nodiscard]] auto get() const noexcept
   {
     if constexpr (I == 0) {
-      return m_filename;
+      return std::string_view(m_filename);
     } else if constexpr (I == 1) {
       return m_offset;
     } else if constexpr (I == 2) {
@@ -181,7 +194,8 @@ template<is_insertable_or_ostream T>
 static void
   append_entry(T &output, const FileData fd)
 {
-  const auto string = fd.get_path_string();
+  std::string string = std::string(fd.get_path_string_view());
+  tl::string::undo_replace_slashes(string);
   tl::write::append(output, static_cast<std::uint32_t>(std::size(string)));
   tl::write::append(output, string);
   tl::write::append(output, fd.offset(), fd.uncompressed_size());
@@ -205,7 +219,7 @@ struct [[maybe_unused]] tuple_size<open_viii::archive::FileData>
 template<>
 struct [[maybe_unused]] tuple_element<0, open_viii::archive::FileData>
 {
-  using type = std::basic_string<char>;
+  using type = std::string_view;
 };
 /**
  * type of 2nd argument

--- a/ut/FI.cpp
+++ b/ut/FI.cpp
@@ -47,5 +47,13 @@ int
       expect(eq(FI::get_fi_entry_offset(1U, 0U), 12U));
       expect(eq(FI::get_fi_entry_offset(19U, 55U), 283U));
     };
+    "FI append"_test = [] {
+      std::vector<char> buffer{};
+      append_entry(buffer, FI(5U, 10U));
+      expect(eq(std::size(buffer), 12U));
+      const auto local_fi = FI(buffer, 0U, 0U);
+      expect(eq(local_fi.offset(), 10U));
+      expect(eq(local_fi.uncompressed_size(), 5U));
+    };
   };
 }

--- a/ut/FL.cpp
+++ b/ut/FL.cpp
@@ -12,6 +12,7 @@ int
   using namespace boost::ut;
   using namespace std::string_literals;
   using namespace std::string_view_literals;
+  using namespace open_viii::archive;
   [[maybe_unused]] suite tests = [] {
     {
       static const auto check_path_strings = [](std::string &&input) {
@@ -151,5 +152,17 @@ C:\ff8\Data\eng\FIELD\mapdata\bc\bcform1a.fi)"s;
         check({ "form"sv }, "ff8/Data/eng/FIELD/mapdata/bc/bcform1a.fi"sv);
       };
     }
+    "FileData append"_test = [] {
+      std::string buffer{};
+      append_entry(buffer, "test/test1.test"sv);
+      append_entry(buffer, "test/test2.test"sv);
+      append_entry(buffer, "test/test3.test"sv);
+      expect(eq(buffer[7], '\\'));
+      expect(eq(std::size(buffer), 60U));
+      const auto entries = open_viii::archive::fl::get_all_entries("",buffer,0U);
+      expect(eq(entries.at(0).second, "test/test1.test"sv));
+      expect(eq(entries.at(1).second, "test/test2.test"sv));
+      expect(eq(entries.at(2).second, "test/test3.test"sv));
+    };
   };
 }

--- a/ut/FS.cpp
+++ b/ut/FS.cpp
@@ -125,7 +125,7 @@ int
       const auto        add_uncompressed_data =
         [&uncompressed_buffer, &fi_buffer](const mock_span_data &mock) {
           fi_buffer.push_back(
-            FS::append_entry(uncompressed_buffer, mock.span(), mock.fi()));
+            append_entry(uncompressed_buffer, mock.span(), mock.fi()));
         };
       add_uncompressed_data(mock1);
       add_uncompressed_data(mock2);
@@ -143,7 +143,7 @@ int
       std::vector<char> compressed_buffer{};
       const auto        add_lzss_data = [&compressed_buffer,
                                   &fi_buffer](const mock_span_data &mock) {
-        fi_buffer.push_back(FS::append_entry(
+        fi_buffer.push_back(append_entry(
           compressed_buffer, mock.span(), open_viii::CompressionTypeT::lzss));
       };
       add_lzss_data(mock1);
@@ -173,7 +173,7 @@ int
       std::vector<char> compressed_buffer{};
       const auto        add_l4z_data = [&compressed_buffer,
                                  &fi_buffer](const mock_span_data &mock) {
-        fi_buffer.push_back(FS::append_entry(
+        fi_buffer.push_back(append_entry(
           compressed_buffer, mock.span(), open_viii::CompressionTypeT::lz4));
       };
       add_l4z_data(mock1);
@@ -203,7 +203,7 @@ int
       std::stringstream compressed_buffer{};
       const auto        add_l4z_data = [&compressed_buffer,
                                  &fi_buffer](const mock_span_data &mock) {
-        fi_buffer.push_back(FS::append_entry(
+        fi_buffer.push_back(append_entry(
           compressed_buffer, mock.span(), open_viii::CompressionTypeT::lz4));
       };
       add_l4z_data(mock1);
@@ -223,7 +223,7 @@ int
       std::stringstream compressed_buffer{};
       const auto        add_lzss_data = [&compressed_buffer,
         &fi_buffer](const mock_span_data &mock) {
-        fi_buffer.push_back(FS::append_entry(
+        fi_buffer.push_back(append_entry(
           compressed_buffer, mock.span(), open_viii::CompressionTypeT::lzss));
       };
       add_lzss_data(mock1);
@@ -243,7 +243,7 @@ int
       std::stringstream compressed_buffer{};
       const auto        add_uncompressed_data = [&compressed_buffer,
         &fi_buffer](const mock_span_data &mock) {
-        fi_buffer.push_back(FS::append_entry(
+        fi_buffer.push_back(append_entry(
           compressed_buffer, mock.span(), open_viii::CompressionTypeT::none));
       };
       add_uncompressed_data(mock1);

--- a/ut/FS.cpp
+++ b/ut/FS.cpp
@@ -6,6 +6,7 @@
 #include "open_viii/compression/L4Z.hpp"
 #include "open_viii/compression/LZSS.hpp"
 #include "tl/utility.hpp"
+#include "tl/write.hpp"
 #include <algorithm>
 #include <cstdint>
 #include <ranges>

--- a/ut/FS.cpp
+++ b/ut/FS.cpp
@@ -4,16 +4,10 @@
 #include "open_viii/archive/FI.hpp"
 #include "open_viii/archive/FS.hpp"
 #include "open_viii/compression/L4Z.hpp"
-#include "open_viii/compression/LZSS.hpp"
-#include "tl/utility.hpp"
-#include "tl/write.hpp"
 #include <algorithm>
 #include <cstdint>
-#include <ranges>
-#include <sstream>
+#include <span>
 #include <string_view>
-// TODO export the FS writing code into the FS.hpp, I had to write the code to
-// write FS to have something for the read tests to use.
 /**
  * Mock span data, this is grouping values together for tests. The raw data is
  * in a string_view and the span points to the same data. Because if you pass a
@@ -26,6 +20,7 @@ private:
   std::string_view       m_string_view{};
   std::span<const char>  m_span{};
   open_viii::archive::FI m_fi{};
+
 public:
   constexpr mock_span_data(std::string_view            string_view,
                            std::uint32_t               offset = 0,
@@ -98,7 +93,15 @@ int
     };
     static constexpr auto check_fs2 =
       [](auto full_data, const mock_span_data &mock, const FI &fi) {
-        const auto value = FS::get_entry(full_data, fi);
+        const auto value = [&]() {
+          if constexpr (requires(decltype(full_data) fd) {
+                          std::span<const char>(fd);
+                        }) {
+            return FS::get_entry(std::span<const char>(full_data), fi);
+          } else {
+            return FS::get_entry(full_data, fi);
+          }
+        }();
         expect(std::ranges::equal(value, mock.string_view()));
       };
     "read entire span"_test = [] {
@@ -191,6 +194,66 @@ int
         check_fs2(compressed_temp_file.value(), mock1, fi_buffer[0]);
         check_fs2(compressed_temp_file.value(), mock2, fi_buffer[1]);
         check_fs2(compressed_temp_file.value(), mock3, fi_buffer[2]);
+      };
+    }
+    {
+      // write compressed L4Z data to buffer stream
+      std::vector<FI> fi_buffer{};
+      fi_buffer.reserve(3);
+      std::stringstream compressed_buffer{};
+      const auto        add_l4z_data = [&compressed_buffer,
+                                 &fi_buffer](const mock_span_data &mock) {
+        fi_buffer.push_back(FS::append_entry(
+          compressed_buffer, mock.span(), open_viii::CompressionTypeT::lz4));
+      };
+      add_l4z_data(mock1);
+      add_l4z_data(mock2);
+      add_l4z_data(mock3);
+      std::string string_buffer = compressed_buffer.str();
+      "read entire span"_test   = [&string_buffer, &fi_buffer] {
+        check_fs2(string_buffer, mock1, fi_buffer[0]);
+        check_fs2(string_buffer, mock2, fi_buffer[1]);
+        check_fs2(string_buffer, mock3, fi_buffer[2]);
+      };
+    }
+    {
+      // write compressed LZSS data to buffer stream
+      std::vector<FI> fi_buffer{};
+      fi_buffer.reserve(3);
+      std::stringstream compressed_buffer{};
+      const auto        add_lzss_data = [&compressed_buffer,
+        &fi_buffer](const mock_span_data &mock) {
+        fi_buffer.push_back(FS::append_entry(
+          compressed_buffer, mock.span(), open_viii::CompressionTypeT::lzss));
+      };
+      add_lzss_data(mock1);
+      add_lzss_data(mock2);
+      add_lzss_data(mock3);
+      std::string string_buffer = compressed_buffer.str();
+      "read entire span"_test   = [&string_buffer, &fi_buffer] {
+        check_fs2(string_buffer, mock1, fi_buffer[0]);
+        check_fs2(string_buffer, mock2, fi_buffer[1]);
+        check_fs2(string_buffer, mock3, fi_buffer[2]);
+      };
+    }
+    {
+      // write compressed uncompressed data to buffer stream
+      std::vector<FI> fi_buffer{};
+      fi_buffer.reserve(3);
+      std::stringstream compressed_buffer{};
+      const auto        add_uncompressed_data = [&compressed_buffer,
+        &fi_buffer](const mock_span_data &mock) {
+        fi_buffer.push_back(FS::append_entry(
+          compressed_buffer, mock.span(), open_viii::CompressionTypeT::none));
+      };
+      add_uncompressed_data(mock1);
+      add_uncompressed_data(mock2);
+      add_uncompressed_data(mock3);
+      std::string string_buffer = compressed_buffer.str();
+      "read entire span"_test   = [&string_buffer, &fi_buffer] {
+        check_fs2(string_buffer, mock1, fi_buffer[0]);
+        check_fs2(string_buffer, mock2, fi_buffer[1]);
+        check_fs2(string_buffer, mock3, fi_buffer[2]);
       };
     }
   };

--- a/ut/FileData.cpp
+++ b/ut/FileData.cpp
@@ -10,6 +10,7 @@ int
   using namespace boost::ut;
   using namespace boost::ut::bdd;
   using namespace std::string_view_literals;
+  using namespace std::string_literals;
   using namespace open_viii::archive;
   using namespace open_viii;
   [[maybe_unused]] suite tests = [] {
@@ -65,8 +66,8 @@ int
           expects(FileData(252U, 658U), {}, 16U, 658U, 252U, true);
         };
         then("A string, a size and an offset") = [] {
-          expects(FileData(R"(test\test)"sv, 252U, 658U),
-                  "test/test"sv,
+          expects(FileData(R"(test\test)"s, 252U, 658U),
+                  "test/test"s,
                   25U,
                   658U,
                   252U,
@@ -91,6 +92,16 @@ int
         auto input = tl::read::input(sample_hex, true);
         check_fd_sample(input);
       };
+    };
+    "FileData append"_test = [] {
+      std::vector<char> buffer{};
+      append_entry(buffer, FileData("test/test.test",5U, 10U));
+      expect(eq(buffer[8], '\\'));
+      expect(eq(std::size(buffer), 30U));
+      const auto local_fi = FileData(buffer);
+      expect(eq(local_fi.get_path_string(), "test/test.test"sv));
+      expect(eq(local_fi.offset(), 5U));
+      expect(eq(local_fi.uncompressed_size(), 10U));
     };
   };
 }


### PR DESCRIPTION
I added append to FS a while ago. I wanted to add it to FileData FI, and FL. It's a free function. So I can do more overloads for like FIFLFS and ZZZ later. I also Added tests for the new functions.
related https://github.com/Sebanisu/OpenVIII_CPP_WIP/issues/21