### PR TITLE
promote shared deps to PUBLIC and add fmt for downstream linkage testing

### DIFF
--- a/src/open_viii/graphics/CMakeLists.txt
+++ b/src/open_viii/graphics/CMakeLists.txt
@@ -9,11 +9,13 @@ add_subdirectory(tex)
 add_subdirectory(sp2)
 find_package(PNG REQUIRED)
 target_link_libraries(${PROJECT_NAME}_VIIIGraphics
-    PUBLIC
-        ToolsLibrary_tl
-        ${PROJECT_NAME}_VIIITools
-        ${PROJECT_NAME}_VIIICommon
-        PNG::PNG
+    PUBLIC ToolsLibrary_tl
+    PUBLIC ${PROJECT_NAME}_VIIITools
+    PUBLIC ${PROJECT_NAME}_VIIICommon
+    PUBLIC ${PROJECT_NAME}_project_warnings
+    PUBLIC PNG::PNG
+    PUBLIC spdlog::spdlog
+    PUBLIC Threads::Threads
 )
 
 target_include_directories(${PROJECT_NAME}_VIIIGraphics

--- a/src/open_viii/paths/CMakeLists.txt
+++ b/src/open_viii/paths/CMakeLists.txt
@@ -7,9 +7,11 @@ add_library(${PROJECT_NAME}_VIIIPaths STATIC
 target_link_libraries(${PROJECT_NAME}_VIIIPaths
     PUBLIC ${PROJECT_NAME}_VIIICommon
     PUBLIC ${PROJECT_NAME}_VIIITools
+    PUBLIC ${PROJECT_NAME}_project_warnings
+    PUBLIC ctre::ctre
+    PUBLIC spdlog::spdlog
+    PUBLIC Threads::Threads
 )
-
-target_link_libraries(${PROJECT_NAME}_VIIIPaths PRIVATE ctre::ctre)
 
 apply_common_operations(VIIIPaths)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,13 +2,14 @@
   "name": "openviii-cpp-wip",
   "version": "0.1.0",
   "description": "A WIP project for OPENVIII in C++",
-  "builtin-baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f",
+  "builtin-baseline": "4f1406d8f7923c3fff34738b6177f72b143ad5b6",
   "dependencies": [
     "ctre",
     "libpng",
     "bext-ut",
     "lz4",
-    "spdlog"
+    "spdlog",
+    "fmt"
   ],
   "overrides":[
     {
@@ -34,6 +35,11 @@
     {
       "name": "spdlog",
       "version": "1.15.3",
+      "port-version": 0
+    },
+    {
+      "name": "fmt",
+      "version": "12.0.0",
       "port-version": 0
     }
   ]


### PR DESCRIPTION
## Summary

Adjusts dependency linkage visibility for `VIIIGraphics` and `VIIIPaths` and updates vcpkg dependencies/baseline.

This promotes several libraries from private/implicit usage to explicit `PUBLIC` linkage so downstream consumers inherit the required dependencies automatically. The change is primarily intended to test whether missing transitive linkage is the source of downstream integration/build issues.

## Changes

* Promote shared dependencies to `PUBLIC` linkage:

  * `spdlog::spdlog`
  * `Threads::Threads`
  * `ctre::ctre`
  * `${PROJECT_NAME}_project_warnings`
* Normalize `target_link_libraries()` formatting
* Add `fmt` to `vcpkg.json`
* Update vcpkg builtin baseline
* Pin `fmt` override version

## Notes

This is mostly a build-system/linkage propagation change and should not affect runtime behavior directly. The goal is to make dependency requirements explicit and consistently available to downstream targets.
