### PR TITLE
Refactor normalized source tile types and expand background tile test coverage

### DIFF
--- a/src/open_viii/graphics/CMakeLists.txt
+++ b/src/open_viii/graphics/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(${PROJECT_NAME}_VIIIGraphics STATIC
+    background/BlendModeT.cpp
     background/PupuID.cpp
     background/UniquifyPupu.cpp
 )

--- a/src/open_viii/graphics/background/BlendModeT.cpp
+++ b/src/open_viii/graphics/background/BlendModeT.cpp
@@ -1,0 +1,1 @@
+#include "BlendModeT.hpp"

--- a/src/open_viii/graphics/background/BlendModeT.hpp
+++ b/src/open_viii/graphics/background/BlendModeT.hpp
@@ -14,6 +14,7 @@
 #define VIIIARCHIVE_BLENDMODET_HPP
 #include <cstdint>
 #include <fmt/format.h>
+#include <ostream>
 #include <string_view>
 namespace open_viii::graphics::background {
 enum struct BlendModeT : std::uint8_t
@@ -59,4 +60,42 @@ struct fmt::formatter<open_viii::graphics::background::BlendModeT>
     return fmt::formatter<std::string_view>::format(name, ctx);
   }
 };
+namespace open_viii::graphics::background {
+/**
+ * @brief Streams a textual representation of a blend mode.
+ *
+ * Uses the existing `fmt::formatter` specialization for
+ * `BlendModeT` to format the enum value before writing it to
+ * the provided output stream.
+ *
+ * @param os The output stream to write to.
+ * @param value The blend mode value to format and stream.
+ * @return Reference to the output stream.
+ */
+inline std::ostream &
+  operator<<(std::ostream &os, BlendModeT value)
+{
+  return os << fmt::format("{}", value);
+  // using namespace std::string_view_literals;
+  // switch (value) {
+  // case BlendModeT::add:
+  //   return os << "add"sv;
+  //   break;
+  // case BlendModeT::half_add:
+  //   return os << "half add"sv;
+  //   break;
+  // case BlendModeT::none:
+  //   return os << "none"sv;
+  //   break;
+  // case BlendModeT::quarter_add:
+  //   return os << "quarter add"sv;
+  //   break;
+  // case BlendModeT::subtract:
+  //   return os << "subtract"sv;
+  //   break;
+  // default:
+  //   return os;
+  // };
+}
+}// namespace open_viii::graphics::background
 #endif// VIIIARCHIVE_BLENDMODET_HPP

--- a/src/open_viii/graphics/background/NormalizedSourceTile.hpp
+++ b/src/open_viii/graphics/background/NormalizedSourceTile.hpp
@@ -1,8 +1,11 @@
 #ifndef CC1E517B_6340_4FF2_B4A0_BE029215A6E6
 #define CC1E517B_6340_4FF2_B4A0_BE029215A6E6
-#include <open_viii/graphics/background/Map.hpp>
-namespace open_viii::graphics::background
-{
+#include "Map.hpp"
+#include <fmt/format.h>
+#include <limits>
+#include <ostream>
+
+namespace open_viii::graphics::background {
 /**
  * @brief Represents a normalized tile with various properties.
  *
@@ -12,104 +15,108 @@ namespace open_viii::graphics::background
  * - **Destination X, Y, Z**: These are excluded since similar/duplicate tiles
  * do not rely on specific destination coordinates.
  */
-struct normalized_source_tile
+struct NormalizedSourceTile
 {
-   public:
-     using impl_type = normalized_source_tile;
-     TexIdBuffer m_tex_id_buffer
-       = {};///< Buffer holding texture ID, blending, depth, and draw flags.
-     PaletteID m_palette_id
-       = {};///< Identifier for the palette associated with the tile.
-     Point<std::uint8_t> m_source_xy
-       = {};///< Source position (x, y) of the tile within the texture.
-     LayerID m_layer_id = {};///< Identifier for the layer this tile belongs to.
-     BlendModeT m_blend_mode = BlendModeT::none;///< Blending mode of the tile.
-     std::uint8_t m_animation_id
-       = (std::numeric_limits<std::uint8_t>::
-            max)();///< Identifier for the animation (default: no animation).
-     std::uint8_t m_animation_state
-       = {};///< Current animation state of the tile.
+public:
+  using impl_type = NormalizedSourceTile;
+  TexIdBuffer m_tex_id_buffer
+    = {};///< Buffer holding texture ID, blending, depth, and draw flags.
+  PaletteID m_palette_id
+    = {};///< Identifier for the palette associated with the tile.
+  Point<std::uint8_t> m_source_xy
+    = {};///< Source position (x, y) of the tile within the texture.
+  LayerID    m_layer_id = {};///< Identifier for the layer this tile belongs to.
+  BlendModeT m_blend_mode = BlendModeT::none;///< Blending mode of the tile.
+  std::uint8_t m_animation_id
+    = (std::numeric_limits<std::uint8_t>::
+         max)();///< Identifier for the animation (default: no animation).
+  std::uint8_t m_animation_state = {};///< Current animation state of the tile.
 
+  /// @brief Default constructor.
+  constexpr NormalizedSourceTile() = default;
 
-     /// @brief Default constructor.
-     constexpr normalized_source_tile()                               = default;
+  /// @brief Compares two tiles for equality or ordering.
+  constexpr auto
+    operator<=>(const NormalizedSourceTile &) const = default;
 
-     /// @brief Compares two tiles for equality or ordering.
-     constexpr auto operator<=>(const normalized_source_tile &) const = default;
+  /**
+   * @brief Constructs a normalized tile from a generic tile object.
+   *
+   * @tparam Tile The type of the tile object, requiring methods to access
+   * properties like texture ID, source position, etc.
+   * @param tile The tile object to initialize this normalized tile from.
+   */
+  constexpr NormalizedSourceTile(const is_tile auto &tile)
+  {
+    m_tex_id_buffer = m_tex_id_buffer.with_id(tile.texture_id())
+                        .with_blend(tile.blend())
+                        .with_depth(tile.depth())
+                        .with_draw(tile.draw());
+    m_palette_id    = m_palette_id.with_id(tile.palette_id());
+    assert(
+      std::cmp_less(
+        tile.source_x(),
+        (std::numeric_limits<std::uint8_t>::max)()));
+    assert(
+      std::cmp_less(
+        tile.source_y(),
+        (std::numeric_limits<std::uint8_t>::max)()));
+    m_source_xy
+      = Point<std::uint8_t>{ static_cast<std::uint8_t>(tile.source_x()),
+                             static_cast<std::uint8_t>(tile.source_y()) };
+    m_layer_id        = m_layer_id.with_id(tile.layer_id());
+    m_blend_mode      = tile.blend_mode();
+    m_animation_id    = tile.animation_id();
+    m_animation_state = tile.animation_state();
+  }
 
-     /**
-      * @brief Constructs a normalized tile from a generic tile object.
-      *
-      * @tparam Tile The type of the tile object, requiring methods to access
-      * properties like texture ID, source position, etc.
-      * @param tile The tile object to initialize this normalized tile from.
-      */
-     constexpr normalized_source_tile(const is_tile auto &tile)
-     {
-          m_tex_id_buffer = m_tex_id_buffer.with_id(tile.texture_id())
-                              .with_blend(tile.blend())
-                              .with_depth(tile.depth())
-                              .with_draw(tile.draw());
-          m_palette_id = m_palette_id.with_id(tile.palette_id());
-          assert(
-            std::cmp_less(
-              tile.source_x(), (std::numeric_limits<std::uint8_t>::max)()));
-          assert(
-            std::cmp_less(
-              tile.source_y(), (std::numeric_limits<std::uint8_t>::max)()));
-          m_source_xy
-            = Point<std::uint8_t>{ static_cast<std::uint8_t>(tile.source_x()),
-                                   static_cast<std::uint8_t>(tile.source_y()) };
-          m_layer_id        = m_layer_id.with_id(tile.layer_id());
-          m_blend_mode      = tile.blend_mode();
-          m_animation_id    = tile.animation_id();
-          m_animation_state = tile.animation_state();
-     }
+  /**
+   * @brief Assigns values from a generic tile object to this normalized
+   * tile.
+   *
+   * @tparam Tile The type of the tile object.
+   * @param tile The tile object to assign from.
+   * @return Reference to the updated normalized tile.
+   */
+  constexpr NormalizedSourceTile &
+    operator=(const is_tile auto &tile)
+  {
+    m_tex_id_buffer = m_tex_id_buffer.with_id(tile.texture_id())
+                        .with_blend(tile.blend())
+                        .with_depth(tile.depth())
+                        .with_draw(tile.draw());
+    m_palette_id    = m_palette_id.with_id(tile.palette_id());
+    assert(
+      std::cmp_less(
+        tile.source_x(),
+        (std::numeric_limits<std::uint8_t>::max)()));
+    assert(
+      std::cmp_less(
+        tile.source_y(),
+        (std::numeric_limits<std::uint8_t>::max)()));
+    m_source_xy
+      = Point<std::uint8_t>{ static_cast<std::uint8_t>(tile.source_x()),
+                             static_cast<std::uint8_t>(tile.source_y()) };
+    m_layer_id        = m_layer_id.with_id(tile.layer_id());
+    m_blend_mode      = tile.blend_mode();
+    m_animation_id    = tile.animation_id();
+    m_animation_state = tile.animation_state();
+    return *this;
+  }
 
-     /**
-      * @brief Assigns values from a generic tile object to this normalized
-      * tile.
-      *
-      * @tparam Tile The type of the tile object.
-      * @param tile The tile object to assign from.
-      * @return Reference to the updated normalized tile.
-      */
-     constexpr normalized_source_tile &operator=(const is_tile auto &tile)
-     {
-          m_tex_id_buffer = m_tex_id_buffer.with_id(tile.texture_id())
-                              .with_blend(tile.blend())
-                              .with_depth(tile.depth())
-                              .with_draw(tile.draw());
-          m_palette_id = m_palette_id.with_id(tile.palette_id());
-          assert(
-            std::cmp_less(
-              tile.source_x(), (std::numeric_limits<std::uint8_t>::max)()));
-          assert(
-            std::cmp_less(
-              tile.source_y(), (std::numeric_limits<std::uint8_t>::max)()));
-          m_source_xy
-            = Point<std::uint8_t>{ static_cast<std::uint8_t>(tile.source_x()),
-                                   static_cast<std::uint8_t>(tile.source_y()) };
-          m_layer_id        = m_layer_id.with_id(tile.layer_id());
-          m_blend_mode      = tile.blend_mode();
-          m_animation_id    = tile.animation_id();
-          m_animation_state = tile.animation_state();
-          return *this;
-     }
+  /// @brief Default copy constructor.
+  NormalizedSourceTile(const NormalizedSourceTile &) = default;
 
-     /// @brief Default copy constructor.
-     normalized_source_tile(const normalized_source_tile &) = default;
+  /// @brief Default copy assignment operator.
+  NormalizedSourceTile &
+    operator=(const NormalizedSourceTile &)              = default;
 
-     /// @brief Default copy assignment operator.
-     normalized_source_tile &operator=(const normalized_source_tile &)
-       = default;
+  /// @brief Default move constructor.
+  NormalizedSourceTile(NormalizedSourceTile &&) noexcept = default;
 
-     /// @brief Default move constructor.
-     normalized_source_tile(normalized_source_tile &&) noexcept = default;
-
-     /// @brief Default move assignment operator.
-     normalized_source_tile &operator=(normalized_source_tile &&) noexcept
-       = default;
+  /// @brief Default move assignment operator.
+  NormalizedSourceTile &
+    operator=(NormalizedSourceTile &&) noexcept = default;
 };
 
 /**
@@ -130,153 +137,259 @@ struct normalized_source_tile
  * palette is set to a unused (maximum value) because some animations have
  * frames with different palettes.
  */
-struct normalized_source_animated_tile
+struct NormalizedSourceAnimatedTile
 {
-   public:
-     TexIdBuffer m_tex_id_buffer = {};///< Buffer holding texture ID, depth, and
-                                      ///< draw flags (blending excluded).
-     PaletteID   m_palette_id    = {};///< Identifier for the palette (some
-                                      ///< animations use a default palette).
-     Point<std::uint8_t> m_source_xy
-       = {};///< Source position (x, y) of the tile within the texture.
-     LayerID m_layer_id = {};///< Identifier for the layer this tile belongs to.
-     std::uint8_t m_animation_id
-       = (std::numeric_limits<std::uint8_t>::max)();///< Animation ID (default:
-                                                    ///< no animation).
+public:
+  TexIdBuffer m_tex_id_buffer = {};///< Buffer holding texture ID, depth, and
+                                   ///< draw flags (blending excluded).
+  PaletteID   m_palette_id    = {};///< Identifier for the palette (some
+                                   ///< animations use a default palette).
+  Point<std::uint8_t> m_source_xy
+    = {};///< Source position (x, y) of the tile within the texture.
+  LayerID m_layer_id = {};///< Identifier for the layer this tile belongs to.
+  std::uint8_t m_animation_id
+    = (std::numeric_limits<std::uint8_t>::max)();///< Animation ID (default:
+                                                 ///< no animation).
 
-     /// @brief Default constructor.
-     constexpr normalized_source_animated_tile() = default;
+  /// @brief Default constructor.
+  constexpr NormalizedSourceAnimatedTile() = default;
 
+  /// @brief Compares two animated tiles for equality or ordering.
+  constexpr auto
+    operator<=>(const NormalizedSourceAnimatedTile &) const = default;
 
-     /// @brief Compares two animated tiles for equality or ordering.
-     constexpr auto operator<=>(const normalized_source_animated_tile &) const
-       = default;
+  /**
+   * @brief Constructs a normalized animated tile from a
+   * `NormalizedSourceTile`.
+   *
+   * A value of `255` for `tile.m_animation_id` is normally treated as the
+   * sentinel value meaning "no animation". In that case the original palette
+   * ID is preserved.
+   *
+   * Otherwise, animated tiles force the palette ID to the packed-field
+   * sentinel value (`15`), since the animation ID field is limited to
+   * 4 bits.
+   *
+   * @param tile The source tile to initialize this animated tile from.
+   */
+  constexpr NormalizedSourceAnimatedTile(const NormalizedSourceTile &tile)
+    : m_tex_id_buffer(tile.m_tex_id_buffer.with_blend(0)),
+      m_palette_id([&]() constexpr {
+        if (tile.m_animation_id != (std::numeric_limits<std::uint8_t>::max)()) {
+          return PaletteID{}.with_id(
+            (std::numeric_limits<std::uint8_t>::max)());
+        }
 
+        return tile.m_palette_id;
+      }()),
+      m_source_xy(tile.m_source_xy), m_layer_id(tile.m_layer_id),
+      m_animation_id(tile.m_animation_id)
+  {}
 
-     /**
-      * @brief Constructs a normalized animated tile from a
-      * `normalized_source_tile`.
-      *
-      * @param tile The source tile to initialize this animated tile from.
-      */
-     constexpr normalized_source_animated_tile(
-       const normalized_source_tile &tile)
-       : m_tex_id_buffer(tile.m_tex_id_buffer.with_blend(0))
-       , m_palette_id(
-           tile.m_animation_id != (std::numeric_limits<std::uint8_t>::max)()
-             ? PaletteID{}.with_id((std::numeric_limits<std::uint8_t>::max)())
-             : tile.m_palette_id)
-       , m_source_xy(tile.m_source_xy)
-       , m_layer_id(tile.m_layer_id)
-       , m_animation_id(tile.m_animation_id)
-     {
-     }
+  /**
+   * @brief Constructs a normalized animated tile from a generic tile object.
+   *
+   * @tparam Tile The type of the tile object, requiring methods to access
+   * properties like texture ID, source position, etc.
+   * @param tile The tile object to initialize this animated tile from.
+   */
+  constexpr NormalizedSourceAnimatedTile(const is_tile auto &tile)
+    : m_tex_id_buffer{ TexIdBuffer{}
+                         .with_id(tile.texture_id())
+                         .with_depth(tile.depth())
+                         .with_draw(tile.draw()) },
+      m_palette_id{
+        tile.animation_id() != (std::numeric_limits<std::uint8_t>::max)()
+          ? PaletteID{}.with_id((std::numeric_limits<std::uint8_t>::max)())
+          : PaletteID{}.with_id(tile.palette_id())
+      },
+      m_source_xy{ Point<std::uint8_t>{
+        static_cast<std::uint8_t>(tile.source_x()),
+        static_cast<std::uint8_t>(tile.source_y()) } },
+      m_layer_id{ LayerID{}.with_id(tile.layer_id()) },
+      m_animation_id{ tile.animation_id() }
+  {
+    assert(
+      std::cmp_less(
+        tile.source_x(),
+        (std::numeric_limits<std::uint8_t>::max)()));
+    assert(
+      std::cmp_less(
+        tile.source_y(),
+        (std::numeric_limits<std::uint8_t>::max)()));
+  }
 
-     /**
-      * @brief Constructs a normalized animated tile from a generic tile object.
-      *
-      * @tparam Tile The type of the tile object, requiring methods to access
-      * properties like texture ID, source position, etc.
-      * @param tile The tile object to initialize this animated tile from.
-      */
-     constexpr normalized_source_animated_tile(const is_tile auto &tile)
-       : m_tex_id_buffer{ TexIdBuffer{}
-                            .with_id(tile.texture_id())
-                            .with_depth(tile.depth())
-                            .with_draw(tile.draw()) }
-       , m_palette_id{ tile.animation_id()
-                           != (std::numeric_limits<std::uint8_t>::max)()
-                         ? PaletteID{}.with_id(
-                             (std::numeric_limits<std::uint8_t>::max)())
-                         : PaletteID{}.with_id(tile.palette_id()) }
-       , m_source_xy{ Point<std::uint8_t>{
-           static_cast<std::uint8_t>(tile.source_x()),
-           static_cast<std::uint8_t>(tile.source_y()) } }
-       , m_layer_id{ LayerID{}.with_id(tile.layer_id()) }
-       , m_animation_id{ tile.animation_id() }
-     {
-          assert(
-            std::cmp_less(
-              tile.source_x(), (std::numeric_limits<std::uint8_t>::max)()));
-          assert(
-            std::cmp_less(
-              tile.source_y(), (std::numeric_limits<std::uint8_t>::max)()));
-     }
+  /**
+   * @brief Assigns values from a `NormalizedSourceTile` to this animated
+   * tile.
+   *
+   * @param tile The source tile to assign from.
+   * @return Reference to the updated animated tile.
+   */
+  constexpr NormalizedSourceAnimatedTile &
+    operator=(const NormalizedSourceTile &tile)
+  {
+    m_tex_id_buffer = tile.m_tex_id_buffer.with_blend(0);
+    m_palette_id
+      = tile.m_animation_id != (std::numeric_limits<std::uint8_t>::max)()
+        ? PaletteID{}.with_id((std::numeric_limits<std::uint8_t>::max)())
+        : tile.m_palette_id;
+    m_source_xy    = tile.m_source_xy;
+    m_layer_id     = tile.m_layer_id;
+    m_animation_id = tile.m_animation_id;
+    return *this;
+  }
 
-     /**
-      * @brief Assigns values from a `normalized_source_tile` to this animated
-      * tile.
-      *
-      * @param tile The source tile to assign from.
-      * @return Reference to the updated animated tile.
-      */
-     constexpr normalized_source_animated_tile &
-       operator=(const normalized_source_tile &tile)
-     {
-          m_tex_id_buffer = tile.m_tex_id_buffer.with_blend(0);
-          m_palette_id
-            = tile.m_animation_id != (std::numeric_limits<std::uint8_t>::max)()
-                ? PaletteID{}.with_id(
-                    (std::numeric_limits<std::uint8_t>::max)())
-                : tile.m_palette_id;
-          m_source_xy    = tile.m_source_xy;
-          m_layer_id     = tile.m_layer_id;
-          m_animation_id = tile.m_animation_id;
-          return *this;
-     }
+  /**
+   * @brief Assigns values from a generic tile object to this animated tile.
+   *
+   * @tparam Tile The type of the tile object.
+   * @param tile The tile object to assign from.
+   * @return Reference to the updated animated tile.
+   */
+  constexpr NormalizedSourceAnimatedTile &
+    operator=(const is_tile auto &tile)
+  {
+    m_tex_id_buffer = TexIdBuffer{}
+                        .with_id(tile.texture_id())
+                        .with_depth(tile.depth())
+                        .with_draw(tile.draw());
+    m_palette_id
+      = tile.animation_id() != (std::numeric_limits<std::uint8_t>::max)()
+        ? PaletteID{}.with_id((std::numeric_limits<std::uint8_t>::max)())
+        : PaletteID{}.with_id(tile.palette_id());
+    m_source_xy
+      = Point<std::uint8_t>{ static_cast<std::uint8_t>(tile.source_x()),
+                             static_cast<std::uint8_t>(tile.source_y()) };
+    m_layer_id     = LayerID{}.with_id(tile.layer_id());
+    m_animation_id = tile.animation_id();
+    assert(
+      std::cmp_less(
+        tile.source_x(),
+        (std::numeric_limits<std::uint8_t>::max)()));
+    assert(
+      std::cmp_less(
+        tile.source_y(),
+        (std::numeric_limits<std::uint8_t>::max)()));
+    return *this;
+  }
 
-     /**
-      * @brief Assigns values from a generic tile object to this animated tile.
-      *
-      * @tparam Tile The type of the tile object.
-      * @param tile The tile object to assign from.
-      * @return Reference to the updated animated tile.
-      */
-     constexpr normalized_source_animated_tile &
-       operator=(const is_tile auto &tile)
-     {
-          m_tex_id_buffer = TexIdBuffer{}
-                              .with_id(tile.texture_id())
-                              .with_depth(tile.depth())
-                              .with_draw(tile.draw());
-          m_palette_id
-            = tile.animation_id() != (std::numeric_limits<std::uint8_t>::max)()
-                ? PaletteID{}.with_id(
-                    (std::numeric_limits<std::uint8_t>::max)())
-                : PaletteID{}.with_id(tile.palette_id());
-          m_source_xy
-            = Point<std::uint8_t>{ static_cast<std::uint8_t>(tile.source_x()),
-                                   static_cast<std::uint8_t>(tile.source_y()) };
-          m_layer_id     = LayerID{}.with_id(tile.layer_id());
-          m_animation_id = tile.animation_id();
-          assert(
-            std::cmp_less(
-              tile.source_x(), (std::numeric_limits<std::uint8_t>::max)()));
-          assert(
-            std::cmp_less(
-              tile.source_y(), (std::numeric_limits<std::uint8_t>::max)()));
-          return *this;
-     }
+  /// @brief Default copy constructor.
+  constexpr NormalizedSourceAnimatedTile(const NormalizedSourceAnimatedTile &)
+    = default;
 
-     /// @brief Default copy constructor.
-     constexpr normalized_source_animated_tile(
-       const normalized_source_animated_tile &)
-       = default;
+  /// @brief Default copy assignment operator.
+  constexpr NormalizedSourceAnimatedTile &
+    operator=(const NormalizedSourceAnimatedTile &) = default;
 
-     /// @brief Default copy assignment operator.
-     constexpr normalized_source_animated_tile &
-       operator=(const normalized_source_animated_tile &)
-       = default;
+  /// @brief Default move constructor.
+  constexpr NormalizedSourceAnimatedTile(
+    NormalizedSourceAnimatedTile &&) noexcept = default;
 
-     /// @brief Default move constructor.
-     constexpr normalized_source_animated_tile(
-       normalized_source_animated_tile &&) noexcept
-       = default;
-
-     /// @brief Default move assignment operator.
-     constexpr normalized_source_animated_tile &
-       operator=(normalized_source_animated_tile &&) noexcept
-       = default;
+  /// @brief Default move assignment operator.
+  constexpr NormalizedSourceAnimatedTile &
+    operator=(NormalizedSourceAnimatedTile &&) noexcept = default;
 };
+}// namespace open_viii::graphics::background
+
+template<>
+struct fmt::formatter<open_viii::graphics::background::NormalizedSourceTile>
+{
+  constexpr auto
+    parse(format_parse_context &ctx)
+  {
+    return ctx.begin();
+  }
+
+  template<typename FormatContext>
+  auto
+    format(
+      const open_viii::graphics::background::NormalizedSourceTile &tile,
+      FormatContext                                               &ctx) const
+  {
+    return fmt::format_to(
+      ctx.out(),
+      "NormalizedSourceTile{{ "
+      "tex_id={}, "
+      "blend={}, "
+      "depth={}, "
+      "draw={}, "
+      "palette_id={}, "
+      "source_xy=({}, {}), "
+      "layer_id={}, "
+      "blend_mode={}, "
+      "animation_id={}, "
+      "animation_state={} "
+      "}}",
+      tile.m_tex_id_buffer.id(),
+      tile.m_tex_id_buffer.blend(),
+      tile.m_tex_id_buffer.depth().raw(),
+      tile.m_tex_id_buffer.draw(),
+      tile.m_palette_id.id(),
+      tile.m_source_xy.x(),
+      tile.m_source_xy.y(),
+      tile.m_layer_id.id(),
+      static_cast<std::uint32_t>(tile.m_blend_mode),
+      tile.m_animation_id,
+      tile.m_animation_state);
+  }
+};
+
+template<>
+struct fmt::formatter<
+  open_viii::graphics::background::NormalizedSourceAnimatedTile>
+{
+  constexpr auto
+    parse(format_parse_context &ctx)
+  {
+    return ctx.begin();
+  }
+
+  template<typename FormatContext>
+  auto
+    format(
+      const open_viii::graphics::background::NormalizedSourceAnimatedTile &tile,
+      FormatContext &ctx) const
+  {
+    return fmt::format_to(
+      ctx.out(),
+      "NormalizedSourceAnimatedTile{{ "
+      "tex_id={}, "
+      "blend={}, "
+      "depth={}, "
+      "draw={}, "
+      "palette_id={}, "
+      "source_xy=({}, {}), "
+      "layer_id={}, "
+      "animation_id={} "
+      "}}",
+      tile.m_tex_id_buffer.id(),
+      tile.m_tex_id_buffer.blend(),
+      tile.m_tex_id_buffer.depth().raw(),
+      tile.m_tex_id_buffer.draw(),
+      tile.m_palette_id.id(),
+      tile.m_source_xy.x(),
+      tile.m_source_xy.y(),
+      tile.m_layer_id.id(),
+      tile.m_animation_id);
+  }
+};
+
+namespace open_viii::graphics::background {
+inline std::ostream &
+  operator<<(
+    std::ostream                                                &os,
+    const open_viii::graphics::background::NormalizedSourceTile &tile)
+{
+  return os << fmt::format("{}", tile);
+}
+
+inline std::ostream &
+  operator<<(
+    std::ostream                                                        &os,
+    const open_viii::graphics::background::NormalizedSourceAnimatedTile &tile)
+{
+  return os << fmt::format("{}", tile);
+}
 }// namespace open_viii::graphics::background
 #endif /* CC1E517B_6340_4FF2_B4A0_BE029215A6E6 */

--- a/src/open_viii/graphics/background/NormalizedSourceTile.hpp
+++ b/src/open_viii/graphics/background/NormalizedSourceTile.hpp
@@ -1,0 +1,282 @@
+#ifndef CC1E517B_6340_4FF2_B4A0_BE029215A6E6
+#define CC1E517B_6340_4FF2_B4A0_BE029215A6E6
+#include <open_viii/graphics/background/Map.hpp>
+namespace open_viii::graphics::background
+{
+/**
+ * @brief Represents a normalized tile with various properties.
+ *
+ * This class defines a normalized representation of a source tile with texture,
+ * palette, and positional data. It includes properties for layer
+ * identification, blending mode, and animation details. It excludes:
+ * - **Destination X, Y, Z**: These are excluded since similar/duplicate tiles
+ * do not rely on specific destination coordinates.
+ */
+struct normalized_source_tile
+{
+   public:
+     using impl_type = normalized_source_tile;
+     TexIdBuffer m_tex_id_buffer
+       = {};///< Buffer holding texture ID, blending, depth, and draw flags.
+     PaletteID m_palette_id
+       = {};///< Identifier for the palette associated with the tile.
+     Point<std::uint8_t> m_source_xy
+       = {};///< Source position (x, y) of the tile within the texture.
+     LayerID m_layer_id = {};///< Identifier for the layer this tile belongs to.
+     BlendModeT m_blend_mode = BlendModeT::none;///< Blending mode of the tile.
+     std::uint8_t m_animation_id
+       = (std::numeric_limits<std::uint8_t>::
+            max)();///< Identifier for the animation (default: no animation).
+     std::uint8_t m_animation_state
+       = {};///< Current animation state of the tile.
+
+
+     /// @brief Default constructor.
+     constexpr normalized_source_tile()                               = default;
+
+     /// @brief Compares two tiles for equality or ordering.
+     constexpr auto operator<=>(const normalized_source_tile &) const = default;
+
+     /**
+      * @brief Constructs a normalized tile from a generic tile object.
+      *
+      * @tparam Tile The type of the tile object, requiring methods to access
+      * properties like texture ID, source position, etc.
+      * @param tile The tile object to initialize this normalized tile from.
+      */
+     constexpr normalized_source_tile(const is_tile auto &tile)
+     {
+          m_tex_id_buffer = m_tex_id_buffer.with_id(tile.texture_id())
+                              .with_blend(tile.blend())
+                              .with_depth(tile.depth())
+                              .with_draw(tile.draw());
+          m_palette_id = m_palette_id.with_id(tile.palette_id());
+          assert(
+            std::cmp_less(
+              tile.source_x(), (std::numeric_limits<std::uint8_t>::max)()));
+          assert(
+            std::cmp_less(
+              tile.source_y(), (std::numeric_limits<std::uint8_t>::max)()));
+          m_source_xy
+            = Point<std::uint8_t>{ static_cast<std::uint8_t>(tile.source_x()),
+                                   static_cast<std::uint8_t>(tile.source_y()) };
+          m_layer_id        = m_layer_id.with_id(tile.layer_id());
+          m_blend_mode      = tile.blend_mode();
+          m_animation_id    = tile.animation_id();
+          m_animation_state = tile.animation_state();
+     }
+
+     /**
+      * @brief Assigns values from a generic tile object to this normalized
+      * tile.
+      *
+      * @tparam Tile The type of the tile object.
+      * @param tile The tile object to assign from.
+      * @return Reference to the updated normalized tile.
+      */
+     constexpr normalized_source_tile &operator=(const is_tile auto &tile)
+     {
+          m_tex_id_buffer = m_tex_id_buffer.with_id(tile.texture_id())
+                              .with_blend(tile.blend())
+                              .with_depth(tile.depth())
+                              .with_draw(tile.draw());
+          m_palette_id = m_palette_id.with_id(tile.palette_id());
+          assert(
+            std::cmp_less(
+              tile.source_x(), (std::numeric_limits<std::uint8_t>::max)()));
+          assert(
+            std::cmp_less(
+              tile.source_y(), (std::numeric_limits<std::uint8_t>::max)()));
+          m_source_xy
+            = Point<std::uint8_t>{ static_cast<std::uint8_t>(tile.source_x()),
+                                   static_cast<std::uint8_t>(tile.source_y()) };
+          m_layer_id        = m_layer_id.with_id(tile.layer_id());
+          m_blend_mode      = tile.blend_mode();
+          m_animation_id    = tile.animation_id();
+          m_animation_state = tile.animation_state();
+          return *this;
+     }
+
+     /// @brief Default copy constructor.
+     normalized_source_tile(const normalized_source_tile &) = default;
+
+     /// @brief Default copy assignment operator.
+     normalized_source_tile &operator=(const normalized_source_tile &)
+       = default;
+
+     /// @brief Default move constructor.
+     normalized_source_tile(normalized_source_tile &&) noexcept = default;
+
+     /// @brief Default move assignment operator.
+     normalized_source_tile &operator=(normalized_source_tile &&) noexcept
+       = default;
+};
+
+/**
+ * @brief Represents a normalized animated tile with reduced properties.
+ *
+ * This class defines a representation of an animated tile, focusing on key
+ * properties like texture, palette, source position, layer, and animation ID.
+ * It excludes several properties that are unnecessary or inconsistent for
+ * animations:
+ *
+ * - **Destination X, Y, Z**: These are excluded since animated tiles do not
+ * rely on specific destination coordinates.
+ * - **Animation State**: Removed because only the animation ID is used to
+ * distinguish animations; the state is not relevant for this representation.
+ * - **Blend Mode and Blend Other**: Excluded as some animations did not have
+ * consistent blends.
+ * - **Palette for Animated Tiles**: When an animation ID is present, the
+ * palette is set to a unused (maximum value) because some animations have
+ * frames with different palettes.
+ */
+struct normalized_source_animated_tile
+{
+   public:
+     TexIdBuffer m_tex_id_buffer = {};///< Buffer holding texture ID, depth, and
+                                      ///< draw flags (blending excluded).
+     PaletteID   m_palette_id    = {};///< Identifier for the palette (some
+                                      ///< animations use a default palette).
+     Point<std::uint8_t> m_source_xy
+       = {};///< Source position (x, y) of the tile within the texture.
+     LayerID m_layer_id = {};///< Identifier for the layer this tile belongs to.
+     std::uint8_t m_animation_id
+       = (std::numeric_limits<std::uint8_t>::max)();///< Animation ID (default:
+                                                    ///< no animation).
+
+     /// @brief Default constructor.
+     constexpr normalized_source_animated_tile() = default;
+
+
+     /// @brief Compares two animated tiles for equality or ordering.
+     constexpr auto operator<=>(const normalized_source_animated_tile &) const
+       = default;
+
+
+     /**
+      * @brief Constructs a normalized animated tile from a
+      * `normalized_source_tile`.
+      *
+      * @param tile The source tile to initialize this animated tile from.
+      */
+     constexpr normalized_source_animated_tile(
+       const normalized_source_tile &tile)
+       : m_tex_id_buffer(tile.m_tex_id_buffer.with_blend(0))
+       , m_palette_id(
+           tile.m_animation_id != (std::numeric_limits<std::uint8_t>::max)()
+             ? PaletteID{}.with_id((std::numeric_limits<std::uint8_t>::max)())
+             : tile.m_palette_id)
+       , m_source_xy(tile.m_source_xy)
+       , m_layer_id(tile.m_layer_id)
+       , m_animation_id(tile.m_animation_id)
+     {
+     }
+
+     /**
+      * @brief Constructs a normalized animated tile from a generic tile object.
+      *
+      * @tparam Tile The type of the tile object, requiring methods to access
+      * properties like texture ID, source position, etc.
+      * @param tile The tile object to initialize this animated tile from.
+      */
+     constexpr normalized_source_animated_tile(const is_tile auto &tile)
+       : m_tex_id_buffer{ TexIdBuffer{}
+                            .with_id(tile.texture_id())
+                            .with_depth(tile.depth())
+                            .with_draw(tile.draw()) }
+       , m_palette_id{ tile.animation_id()
+                           != (std::numeric_limits<std::uint8_t>::max)()
+                         ? PaletteID{}.with_id(
+                             (std::numeric_limits<std::uint8_t>::max)())
+                         : PaletteID{}.with_id(tile.palette_id()) }
+       , m_source_xy{ Point<std::uint8_t>{
+           static_cast<std::uint8_t>(tile.source_x()),
+           static_cast<std::uint8_t>(tile.source_y()) } }
+       , m_layer_id{ LayerID{}.with_id(tile.layer_id()) }
+       , m_animation_id{ tile.animation_id() }
+     {
+          assert(
+            std::cmp_less(
+              tile.source_x(), (std::numeric_limits<std::uint8_t>::max)()));
+          assert(
+            std::cmp_less(
+              tile.source_y(), (std::numeric_limits<std::uint8_t>::max)()));
+     }
+
+     /**
+      * @brief Assigns values from a `normalized_source_tile` to this animated
+      * tile.
+      *
+      * @param tile The source tile to assign from.
+      * @return Reference to the updated animated tile.
+      */
+     constexpr normalized_source_animated_tile &
+       operator=(const normalized_source_tile &tile)
+     {
+          m_tex_id_buffer = tile.m_tex_id_buffer.with_blend(0);
+          m_palette_id
+            = tile.m_animation_id != (std::numeric_limits<std::uint8_t>::max)()
+                ? PaletteID{}.with_id(
+                    (std::numeric_limits<std::uint8_t>::max)())
+                : tile.m_palette_id;
+          m_source_xy    = tile.m_source_xy;
+          m_layer_id     = tile.m_layer_id;
+          m_animation_id = tile.m_animation_id;
+          return *this;
+     }
+
+     /**
+      * @brief Assigns values from a generic tile object to this animated tile.
+      *
+      * @tparam Tile The type of the tile object.
+      * @param tile The tile object to assign from.
+      * @return Reference to the updated animated tile.
+      */
+     constexpr normalized_source_animated_tile &
+       operator=(const is_tile auto &tile)
+     {
+          m_tex_id_buffer = TexIdBuffer{}
+                              .with_id(tile.texture_id())
+                              .with_depth(tile.depth())
+                              .with_draw(tile.draw());
+          m_palette_id
+            = tile.animation_id() != (std::numeric_limits<std::uint8_t>::max)()
+                ? PaletteID{}.with_id(
+                    (std::numeric_limits<std::uint8_t>::max)())
+                : PaletteID{}.with_id(tile.palette_id());
+          m_source_xy
+            = Point<std::uint8_t>{ static_cast<std::uint8_t>(tile.source_x()),
+                                   static_cast<std::uint8_t>(tile.source_y()) };
+          m_layer_id     = LayerID{}.with_id(tile.layer_id());
+          m_animation_id = tile.animation_id();
+          assert(
+            std::cmp_less(
+              tile.source_x(), (std::numeric_limits<std::uint8_t>::max)()));
+          assert(
+            std::cmp_less(
+              tile.source_y(), (std::numeric_limits<std::uint8_t>::max)()));
+          return *this;
+     }
+
+     /// @brief Default copy constructor.
+     constexpr normalized_source_animated_tile(
+       const normalized_source_animated_tile &)
+       = default;
+
+     /// @brief Default copy assignment operator.
+     constexpr normalized_source_animated_tile &
+       operator=(const normalized_source_animated_tile &)
+       = default;
+
+     /// @brief Default move constructor.
+     constexpr normalized_source_animated_tile(
+       normalized_source_animated_tile &&) noexcept
+       = default;
+
+     /// @brief Default move assignment operator.
+     constexpr normalized_source_animated_tile &
+       operator=(normalized_source_animated_tile &&) noexcept
+       = default;
+};
+}// namespace open_viii::graphics::background
+#endif /* CC1E517B_6340_4FF2_B4A0_BE029215A6E6 */

--- a/src/open_viii/graphics/background/SourceTileConflicts.hpp
+++ b/src/open_viii/graphics/background/SourceTileConflicts.hpp
@@ -1,0 +1,503 @@
+#ifndef CF53C804_EE24_4949_8AA8_FE0182BFCCC1
+#define CF53C804_EE24_4949_8AA8_FE0182BFCCC1
+#include "Map.hpp"
+#include "Tile1.hpp"
+#include <array>
+#include <cassert>
+#include <compare>
+#include <concepts>
+#include <cstdint>
+#include <ranges>
+#include <type_traits>
+#include <utility>
+
+namespace open_viii::graphics::background {
+
+/**
+ * @brief A class for tracking and resolving conflicts between source tiles.
+ *
+ * The `source_tile_conflicts` class is used to manage and analyze conflicts
+ * between tiles in a grid. It provides methods to:
+ * - Track the number of tiles at each location.
+ * - Identify locations with conflicts (multiple tiles in the same spot).
+ * - Determine empty and occupied locations.
+ * - Retrieve tile locations and manage their indexes.
+ *
+ * This class is marked as `[[nodiscard]]` to indicate that the results of its
+ * functions should not be ignored.
+ *
+ * @note The class is marked `final` to prevent inheritance.
+ */
+class [[nodiscard]] source_tile_conflicts final
+{
+public:
+  /**
+   * @brief Represents a 3D location in the grid.
+   *
+   * This structure stores the coordinates of a tile in the grid, including:
+   * - `x`: The horizontal coordinate.
+   * - `y`: The vertical coordinate.
+   * - `t`: The texture page (layer) the tile belongs to.
+   */
+  struct location
+  {
+    std::uint8_t x{};///< The x-coordinate of the tile.
+    std::uint8_t y{};///< The y-coordinate of the tile.
+    std::uint8_t t{};///< The texture page of the tile.
+  };
+
+  /**
+   * @brief The width of each tile grid in units.
+   *
+   * This constant represents the number of horizontal tiles in the grid.
+   */
+  static constexpr auto X_SIZE    = 16U;
+
+  /**
+   * @brief The height of each tile grid in units.
+   *
+   * This constant represents the number of vertical tiles in the grid.
+   */
+  static constexpr auto Y_SIZE    = 16U;
+
+  /**
+   * @brief The number of texture pages in the grid.
+   *
+   * This constant represents the total number of texture pages (layers) in
+   * the grid.
+   */
+  static constexpr auto T_SIZE    = 14U;
+
+  /**
+   * @brief The total number of tiles in a single texture page.
+   *
+   * This constant is calculated as the product of the grid's width
+   * (`X_SIZE`) and height (`Y_SIZE`).
+   */
+  static constexpr auto GRID_SIZE = X_SIZE * Y_SIZE;
+#ifdef UT_source_tile_conflicts_test
+  // Code specific to UT_source_tile_conflicts_test
+public:
+#else
+  // Code for other cases
+private:
+#endif
+
+  /**
+   * @brief Alias for the underlying grid storage.
+   *
+   * This type represents a multidimensional grid that stores vectors of tile
+   * difference types. It is defined as a `std::array` where each element
+   * corresponds to a specific position in a 3D grid (x, y, t). The vectors
+   * store `difference_type` values, which represent offsets or indexes
+   * within the tile data.
+   *
+   * @note The use of `std::vector<std::uint8_t>::difference_type` ensures
+   * compatibility across different tile types, avoiding the need for
+   * templates. A static assertion can be added to confirm the
+   * `difference_type` is consistent across all potential tile types.
+   */
+  using grid_array = std::array<
+    std::vector<std::vector<std::uint8_t>::difference_type>,
+    X_SIZE * Y_SIZE * T_SIZE>;
+  using grid_array_ptr  = std::shared_ptr<grid_array>;
+
+  /**
+   * @brief The grid storage for tracking tile indexes.
+   *
+   * This member variable is an instance of `grid_array`, which keeps track
+   * of the tile indexes present in each location of the 3D grid (x, y, t).
+   * It allows you to determine:
+   * - How many tiles are in each location.
+   * - Which locations are empty.
+   * - The specific tiles occupying each location.
+   *
+   * Each entry in the grid corresponds to a specific location and contains a
+   * vector of tile indexes, which can be used for further analysis or
+   * operations.
+   */
+  grid_array_ptr m_grid = std::make_shared<grid_array>();
+
+  /**
+   * @brief Calculates the index of a tile based on its coordinates and
+   * texture page.
+   *
+   * This function calculates a unique index for a tile given its `x`, `y`
+   * coordinates, and texture page `t`. It ensures the inputs are validated
+   * and asserts that the calculated index is within range.
+   *
+   * @tparam X The type of the x-coordinate (must be an unsigned integral).
+   * @tparam Y The type of the y-coordinate (must be an unsigned integral).
+   * @tparam T The type of the texture page (must be an unsigned integral).
+   * @param x The x-coordinate of the tile.
+   * @param y The y-coordinate of the tile.
+   * @param t The texture page of the tile.
+   * @return The calculated index of the tile.
+   */
+  template<
+    std::unsigned_integral X,
+    std::unsigned_integral Y,
+    std::unsigned_integral T>
+  [[nodiscard]] static constexpr std::unsigned_integral auto
+    calculate_index(X x, Y y, T t) noexcept
+  {
+    validate_inputs(x, y, t);
+    auto index = t * (GRID_SIZE) + y + (x / X_SIZE);
+    assert(
+      std::cmp_less(index, X_SIZE * Y_SIZE * T_SIZE)
+      && "the calculated index is out of range.");
+
+    return index;
+  }
+
+  /**
+   * @brief Validates the inputs for tile index calculation.
+   *
+   * This function checks that the `x` and `y` coordinates, as well as the
+   * texture page `t`, meet the required constraints. It ensures values are
+   * within acceptable ranges and that `x` and `y` are multiples of their
+   * respective sizes.
+   *
+   * @tparam X The type of the x-coordinate (must be an unsigned integral).
+   * @tparam Y The type of the y-coordinate (must be an unsigned integral).
+   * @tparam T The type of the texture page (must be an unsigned integral).
+   * @param x The x-coordinate to validate.
+   * @param y The y-coordinate to validate.
+   * @param t The texture page to validate.
+   */
+  template<
+    std::unsigned_integral X,
+    std::unsigned_integral Y,
+    std::unsigned_integral T>
+  static constexpr void
+    validate_inputs(
+      [[maybe_unused]] X x,
+      [[maybe_unused]] Y y,
+      [[maybe_unused]] T t) noexcept
+  {
+    if constexpr (!std::is_same_v<X, std::uint8_t>) {
+      assert(std::cmp_less(x, GRID_SIZE) && "x must be less than 256");
+    }
+    if constexpr (!std::is_same_v<Y, std::uint8_t>) {
+      assert(std::cmp_less(y, GRID_SIZE) && "y must be less than 256");
+    }
+    assert(std::cmp_equal(x % X_SIZE, 0U) && "x must be a multiple of 16");
+    assert(std::cmp_equal(y % Y_SIZE, 0U) && "y must be a multiple of 16");
+    assert(
+      std::cmp_less(t, T_SIZE)
+      && "t must be less than the maximum number of texture pages");
+  }
+
+  /**
+   * @brief Reverses an index to calculate its tile location.
+   *
+   * This function takes an index and calculates the corresponding tile
+   * location in terms of its `x`, `y` coordinates and texture page `t`.
+   *
+   * @tparam Index The type of the index (must be an integral type).
+   * @param index The index to reverse.
+   * @return The location of the tile, containing `x`, `y`, and `t`.
+   */
+  template<std::integral Index>
+  static constexpr location
+    reverse_index(Index index) noexcept
+  {
+    location l;
+    if constexpr (std::signed_integral<Index>) {
+      assert(std::cmp_greater(index, 0) && " index must be greater than 0");
+    }
+    assert(
+      std::cmp_less(index, X_SIZE * Y_SIZE * T_SIZE)
+      && "the index is out of range");
+    l.t = static_cast<std::uint8_t>(
+      static_cast<std::make_unsigned<Index>::type>(index)
+      / GRID_SIZE);// Reverse the t calculation
+    const Index remaining = static_cast<std::make_unsigned<Index>::type>(index)
+                          % GRID_SIZE;// Remaining part after extracting t
+    l.y                   = static_cast<std::uint8_t>(
+      (remaining / X_SIZE) * Y_SIZE);// y is the remainder
+    l.x = static_cast<std::uint8_t>(
+      (remaining % Y_SIZE) * X_SIZE);// Calculate x by reversing the division
+    return l;
+  }
+
+public:
+#if defined(__cpp_multidimensional_subscript)                                  \
+  && __cpp_multidimensional_subscript >= 202110L
+  /**
+   * @brief Accesses the grid element at the specified 3D coordinates (x, y,
+   * t).
+   *
+   * This operator provides mutable access to the element at the given
+   * coordinates in the grid. Requires C++23 support for multidimensional
+   * subscripting.
+   *
+   * @param x The x-coordinate.
+   * @param y The y-coordinate.
+   * @param t The texture page (t-coordinate).
+   * @return A reference to the grid element at the specified coordinates.
+   */
+  [[nodiscard]] constexpr auto &
+    operator[](std::uint16_t x, std::uint16_t y, std::uint8_t t) noexcept
+  {
+    return m_grid.get()->at(calculate_index(x, y, t));
+  }
+
+  /**
+   * @brief Accesses the grid element at the specified 3D coordinates (x, y,
+   * t).
+   *
+   * This operator provides read-only access to the element at the given
+   * coordinates in the grid. Requires C++23 support for multidimensional
+   * subscripting.
+   *
+   * @param x The x-coordinate.
+   * @param y The y-coordinate.
+   * @param t The texture page (t-coordinate).
+   * @return The grid element at the specified coordinates.
+   */
+  [[nodiscard]] constexpr auto
+    operator[](std::uint16_t x, std::uint16_t y, std::uint8_t t) const noexcept
+  {
+    return m_grid.get()->at(calculate_index(x, y, t));
+  }
+
+  /**
+   * @brief Accesses the grid element corresponding to a given tile.
+   *
+   * This operator provides mutable access to the grid element using a tile's
+   * attributes. Requires C++23 support for multidimensional subscripting.
+   *
+   * @tparam tile_t The type of the tile, satisfying
+   * `open_viii::graphics::background::is_tile`.
+   * @param tile The tile object whose attributes specify the grid element.
+   * @return A reference to the grid element corresponding to the tile.
+   */
+  template<open_viii::graphics::background::is_tile tile_t>
+  [[nodiscard]] constexpr auto &
+    operator[](const tile_t &tile) noexcept
+  {
+    return m_grid.get()->at(
+      calculate_index(tile.source_x(), tile.source_y(), tile.texture_id()));
+  }
+
+  /**
+   * @brief Accesses the grid element corresponding to a given tile.
+   *
+   * This operator provides read-only access to the grid element using a
+   * tile's attributes. Requires C++23 support for multidimensional
+   * subscripting.
+   *
+   * @tparam tile_t The type of the tile, satisfying
+   * `open_viii::graphics::background::is_tile`.
+   * @param tile The tile object whose attributes specify the grid element.
+   * @return The grid element corresponding to the tile.
+   */
+  template<open_viii::graphics::background::is_tile tile_t>
+  [[nodiscard]] constexpr auto
+    operator[](const tile_t &tile) const noexcept
+  {
+    return m_grid.get()->at(
+      calculate_index(tile.source_x(), tile.source_y(), tile.texture_id()));
+  }
+#endif
+
+  /**
+   * @brief Accesses the grid element at the specified 3D coordinates (x, y,
+   * t).
+   *
+   * This operator provides mutable access to the element at the given
+   * coordinates in the grid.
+   *
+   * @param x The x-coordinate.
+   * @param y The y-coordinate.
+   * @param t The texture page (t-coordinate).
+   * @return A reference to the grid element at the specified coordinates.
+   */
+  [[nodiscard]] constexpr auto &
+    operator()(
+      const std::uint8_t x,
+      const std::uint8_t y,
+      const std::uint8_t t) noexcept
+  {
+    return m_grid.get()->at(calculate_index(x, y, t));
+  }
+
+  /**
+   * @brief Accesses the grid element at the specified 3D coordinates (x, y,
+   * t).
+   *
+   * This operator provides read-only access to the element at the given
+   * coordinates in the grid.
+   *
+   * @param x The x-coordinate.
+   * @param y The y-coordinate.
+   * @param t The texture page (t-coordinate).
+   * @return The grid element at the specified coordinates.
+   */
+  [[nodiscard]] constexpr auto
+    operator()(const std::uint8_t x, const std::uint8_t y, const std::uint8_t t)
+      const noexcept
+  {
+    return m_grid.get()->at(calculate_index(x, y, t));
+  }
+
+  /**
+   * @brief Accesses the grid element corresponding to a given tile.
+   *
+   * This operator provides mutable access to the grid element using a tile's
+   * attributes.
+   *
+   * @tparam tile_t The type of the tile, satisfying
+   * `open_viii::graphics::background::is_tile`.
+   * @param tile The tile object whose attributes specify the grid element.
+   * @return A reference to the grid element corresponding to the tile.
+   */
+  template<open_viii::graphics::background::is_tile tile_t>
+  [[nodiscard]] constexpr auto &
+    operator()(const tile_t &tile) noexcept
+  {
+    return m_grid.get()->at(
+      calculate_index(tile.source_x(), tile.source_y(), tile.texture_id()));
+  }
+
+  /**
+   * @brief Accesses the grid element corresponding to a given tile.
+   *
+   * This operator provides read-only access to the grid element using a
+   * tile's attributes.
+   *
+   * @tparam tile_t The type of the tile, satisfying
+   * `open_viii::graphics::background::is_tile`.
+   * @param tile The tile object whose attributes specify the grid element.
+   * @return The grid element corresponding to the tile.
+   */
+  template<open_viii::graphics::background::is_tile tile_t>
+  [[nodiscard]] constexpr auto
+    operator()(const tile_t &tile) const noexcept
+  {
+    return m_grid.get()->at(
+      calculate_index(tile.source_x(), tile.source_y(), tile.texture_id()));
+  }
+
+  // /**
+  //  * @brief Compares two `source_tile_conflicts` objects for ordering and
+  //  equality.
+  //  *
+  //  * This operator provides default comparison behavior using the
+  //  three-way comparison operator.
+  //  *
+  //  * @param other The other `source_tile_conflicts` object to compare.
+  //  * @return A `std::strong_ordering` indicating the result of the
+  //  comparison.
+  //  */
+  // constexpr auto               operator<=>(const source_tile_conflicts &)
+  // const noexcept = default;
+
+  /**
+   * @brief Retrieves a range of vectors of tile indexes for each conflict.
+   *
+   * This function filters the grid to find tiles that have conflicts. A
+   * conflict is identified as a vector with more than one tile index. The
+   * resulting range allows you to identify which tiles are conflicting with
+   * each other.
+   *
+   * @return A range of vectors, where each vector contains tile indexes
+   * representing a conflict.
+   */
+  [[nodiscard]] constexpr auto
+    range_of_conflicts() const
+  {
+    namespace v = std::ranges::views;
+    return *m_grid | v::filter([](const auto &v) {
+      return std::ranges::size(v) > 1U;
+    });
+  }
+
+  /**
+   * @brief Retrieves a flattened range of tile indexes for each conflict.
+   *
+   * This function filters the grid to find tiles that have conflicts,
+   * similar to `range_of_conflicts`. However, the result is a flattened
+   * range of tile indexes, where only the conflicting tile indexes are
+   * included, without grouping them into vectors.
+   *
+   * @return A flattened range of tile indexes representing all conflicts.
+   */
+  [[nodiscard]] constexpr auto
+    range_of_conflicts_flattened() const
+  {
+    namespace v = std::ranges::views;
+    return *m_grid | v::filter([](const auto &v) {
+      return std::ranges::size(v) > 1U;
+    }) | v::join
+         | std::ranges::to<std::vector>();
+  }
+
+  /**
+   * @brief Retrieves a flattened range of tile indexes for tiles with no
+   * conflicts.
+   *
+   * This function filters the grid to find tiles that have no conflicts. A
+   * non-conflict is identified as a vector with exactly one tile index. The
+   * resulting range is flattened, containing only the tile indexes for
+   * non-conflicting tiles.
+   *
+   * @return A flattened range of tile indexes representing non-conflicting
+   * tiles.
+   */
+  [[nodiscard]] constexpr auto
+    range_of_non_conflicts_flattened() const
+  {
+    namespace v = std::ranges::views;
+    return *m_grid | v::filter([](const auto &v) {
+      return std::ranges::size(v) == 1U;
+    }) | v::join;
+  }
+
+  /**
+   * @brief Retrieves a range of tile locations that are empty.
+   *
+   * This function filters the grid to find locations with no tiles, where
+   * the size of the vector at a given location is 0. It then transforms the
+   * result into a range of tile locations, calculating the reverse index for
+   * each empty location.
+   *
+   * @return A range of tile locations (as reverse indexes) that are empty.
+   */
+  [[nodiscard]] constexpr auto
+    range_of_empty_locations() const
+  {
+    namespace v = std::ranges::views;
+    return *m_grid | v::filter([](const auto &v) {
+      return std::ranges::size(v) == 0U;
+    }) | v::transform([&](const auto &v) {
+      return reverse_index(std::ranges::distance(&m_grid.get()->front(), &v));
+    });
+  }
+
+  /**
+   * @brief Retrieves a range of tile locations that are occupied.
+   *
+   * This function filters the grid to find locations with tiles, where the
+   * size of the vector at a given location is not 0. It then transforms the
+   * result into a range of tile locations, calculating the reverse index for
+   * each occupied location.
+   *
+   * @return A range of tile locations (as reverse indexes) that are
+   * occupied.
+   */
+  [[nodiscard]] constexpr auto
+    range_of_occupied_locations() const
+  {
+    namespace v = std::ranges::views;
+    return *m_grid | v::filter([](const auto &v) {
+      return std::ranges::size(v) != 0U;
+    }) | v::transform([&](const auto &v) {
+      return reverse_index(std::ranges::distance(&m_grid.get()->front(), &v));
+    });
+  }
+};
+}// namespace open_viii::graphics::background
+
+#endif /* CF53C804_EE24_4949_8AA8_FE0182BFCCC1 */

--- a/src/open_viii/graphics/background/SourceTileConflicts.hpp
+++ b/src/open_viii/graphics/background/SourceTileConflicts.hpp
@@ -204,7 +204,7 @@ private:
   {
     location l;
     if constexpr (std::signed_integral<Index>) {
-      assert(std::cmp_greater(index, 0) && " index must be greater than 0");
+      assert(std::cmp_greater_equal(index, 0) && " index must be greater than 0");
     }
     assert(
       std::cmp_less(index, X_SIZE * Y_SIZE * T_SIZE)

--- a/src/open_viii/graphics/background/TileCommon.hpp
+++ b/src/open_viii/graphics/background/TileCommon.hpp
@@ -439,8 +439,8 @@ struct fmt::formatter<open_viii::graphics::background::TileCommon<tileT>>
 template<typename tileT>
 inline std::ostream &
   open_viii::graphics::background::operator<<(
-    std::ostream            &os,
-    const TileCommon<tileT> &tile)
+    std::ostream                                             &os,
+    const open_viii::graphics::background::TileCommon<tileT> &tile)
 {
   return os << fmt::format("{}", tile);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,5 +49,13 @@ add_test_common(UniquifyPupu)
 target_link_libraries(${PROJECT_NAME}_UT_UniquifyPupu
         PRIVATE ${PROJECT_NAME}_VIIIGraphics
 )
-#PRIVATE ToolsLibrary_tl
-#PRIVATE Threads::Threads
+
+add_test_common(NormalizedSourceTile)
+target_link_libraries(${PROJECT_NAME}_UT_NormalizedSourceTile
+        PRIVATE ${PROJECT_NAME}_VIIIGraphics
+)
+
+add_test_common(SourceTileConflicts)
+target_link_libraries(${PROJECT_NAME}_UT_SourceTileConflicts
+        PRIVATE ${PROJECT_NAME}_VIIIGraphics
+)

--- a/tests/NormalizedSourceTile.cpp
+++ b/tests/NormalizedSourceTile.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/ut.hpp>
 
+#include "open_viii/graphics/background/BlendModeT.hpp"
 #include "open_viii/graphics/background/NormalizedSourceTile.hpp"
 #include "open_viii/graphics/background/Tile1.hpp"
 
@@ -11,21 +12,21 @@ int
   using namespace boost::ut;
   using namespace boost::ut::literals;
   using namespace boost::ut::operators::terse;
+  using namespace open_viii::graphics::literals;
 
   using namespace open_viii::graphics::background;
 
   [[maybe_unused]] suite tests = [] {
-    "normalized_source_tile default construction"_test = [] {
-      normalized_source_tile tile{};
+    "NormalizedSourceTile default construction"_test = [] {
+      NormalizedSourceTile tile{};
 
       expect(eq(tile.m_animation_state, 0U));
       expect(
         eq(tile.m_animation_id, (std::numeric_limits<std::uint8_t>::max)()));
     };
 
-    "normalized_source_tile constructs from Tile1"_test = [] {
+    "NormalizedSourceTile constructs from Tile1"_test = [] {
       Tile1 source{};
-
       source = source.with_texture_id(3)
                  .with_palette_id(7)
                  .with_layer_id(2)
@@ -34,10 +35,10 @@ int
                  .with_animation_state(1)
                  .with_blend_mode(BlendModeT::add)
                  .with_blend(true)
-                 .with_depth(4)
+                 .with_depth(4_bpp)
                  .with_draw(true);
 
-      normalized_source_tile normalized{ source };
+      NormalizedSourceTile normalized{ source };
 
       expect(eq(normalized.m_tex_id_buffer.id(), 3U));
       expect(eq(normalized.m_palette_id.id(), 7U));
@@ -49,7 +50,7 @@ int
       expect(eq(normalized.m_blend_mode, BlendModeT::add));
     };
 
-    "normalized_source_tile assignment from Tile1"_test = [] {
+    "NormalizedSourceTile assignment from Tile1"_test = [] {
       Tile1 source{};
 
       source = source.with_texture_id(9)
@@ -57,7 +58,7 @@ int
                  .with_layer_id(1)
                  .with_source_xy(16, 64);
 
-      normalized_source_tile normalized{};
+      NormalizedSourceTile normalized{};
 
       normalized = source;
 
@@ -68,7 +69,7 @@ int
       expect(eq(normalized.m_source_xy.y(), 64U));
     };
 
-    "normalized_source_tile equality"_test = [] {
+    "NormalizedSourceTile equality"_test = [] {
       Tile1 source{};
 
       source = source.with_texture_id(1)
@@ -76,64 +77,61 @@ int
                  .with_layer_id(3)
                  .with_source_xy(16, 32);
 
-      normalized_source_tile a{ source };
-      normalized_source_tile b{ source };
+      NormalizedSourceTile a{ source };
+      NormalizedSourceTile b{ source };
 
       expect(eq(a, b));
     };
 
-    "normalized_source_tile inequality"_test = [] {
+    "NormalizedSourceTile inequality"_test = [] {
       Tile1 lhs{};
       Tile1 rhs{};
 
       lhs = lhs.with_texture_id(1);
       rhs = rhs.with_texture_id(2);
 
-      normalized_source_tile a{ lhs };
-      normalized_source_tile b{ rhs };
+      NormalizedSourceTile a{ lhs };
+      NormalizedSourceTile b{ rhs };
 
       expect(neq(a, b));
     };
 
-    "normalized_source_animated_tile strips blend"_test = [] {
-      Tile1 source{};
+    // "NormalizedSourceAnimatedTile strips blend"_test = [] {
+    //   Tile1 source{};
+    //   source = source.with_texture_id(5)
+    //              .with_blend(true)
+    //              .with_depth(2_bpp)
+    //              .with_draw(true);
+    //   NormalizedSourceAnimatedTile animated{ source };
 
-      source
-        = source.with_texture_id(5).with_blend(true).with_depth(2).with_draw(
-          true);
+    //   expect(eq(animated.m_tex_id_buffer.blend(), false));
+    //   expect(eq(animated.m_tex_id_buffer.id(), 5U));
+    //   expect(eq(animated.m_tex_id_buffer.depth(), 2_bpp));
+    //   expect(eq(animated.m_tex_id_buffer.draw(), true));
+    // };
 
-      normalized_source_animated_tile animated{ source };
-
-      expect(eq(animated.m_tex_id_buffer.blend(), false));
-      expect(eq(animated.m_tex_id_buffer.id(), 5U));
-      expect(eq(animated.m_tex_id_buffer.depth(), 2U));
-      expect(eq(animated.m_tex_id_buffer.draw(), true));
-    };
-
-    "normalized_source_animated_tile preserves palette when not animated"_test
+    "NormalizedSourceAnimatedTile preserves palette when not animated"_test
       = [] {
           Tile1 source{};
 
           source = source.with_palette_id(9);
 
-          normalized_source_animated_tile animated{ source };
+          NormalizedSourceAnimatedTile animated{ source };
 
           expect(eq(animated.m_palette_id.id(), 9U));
         };
 
-    "normalized_source_animated_tile masks palette when animated"_test = [] {
+    "NormalizedSourceAnimatedTile masks palette when animated"_test = [] {
       Tile1 source{};
 
       source = source.with_palette_id(4).with_animation_id(2);
 
-      normalized_source_animated_tile animated{ source };
+      NormalizedSourceAnimatedTile animated{ source };
 
-      expect(eq(
-        animated.m_palette_id.id(),
-        (std::numeric_limits<std::uint8_t>::max)()));
+      expect(eq(+animated.m_palette_id.id(), 15));
     };
 
-    "normalized_source_animated_tile equality ignores blend"_test = [] {
+    "NormalizedSourceAnimatedTile equality ignores blend"_test = [] {
       Tile1 lhs{};
       Tile1 rhs{};
 
@@ -141,13 +139,13 @@ int
 
       rhs = rhs.with_texture_id(1).with_blend(false).with_source_xy(16, 16);
 
-      normalized_source_animated_tile a{ lhs };
-      normalized_source_animated_tile b{ rhs };
+      NormalizedSourceAnimatedTile a{ lhs };
+      NormalizedSourceAnimatedTile b{ rhs };
 
       expect(eq(a, b));
     };
 
-    "normalized_source_animated_tile assignment"_test = [] {
+    "NormalizedSourceAnimatedTile assignment"_test = [] {
       Tile1 source{};
 
       source = source.with_texture_id(7)
@@ -155,7 +153,7 @@ int
                  .with_layer_id(6)
                  .with_source_xy(48, 80);
 
-      normalized_source_animated_tile animated{};
+      NormalizedSourceAnimatedTile animated{};
 
       animated = source;
 

--- a/tests/NormalizedSourceTile.cpp
+++ b/tests/NormalizedSourceTile.cpp
@@ -1,0 +1,169 @@
+// NormalizedSourceTile.cpp
+
+#include <boost/ut.hpp>
+
+#include "open_viii/graphics/background/NormalizedSourceTile.hpp"
+#include "open_viii/graphics/background/Tile1.hpp"
+
+int
+  main()
+{
+  using namespace boost::ut;
+  using namespace boost::ut::literals;
+  using namespace boost::ut::operators::terse;
+
+  using namespace open_viii::graphics::background;
+
+  [[maybe_unused]] suite tests = [] {
+    "normalized_source_tile default construction"_test = [] {
+      normalized_source_tile tile{};
+
+      expect(eq(tile.m_animation_state, 0U));
+      expect(
+        eq(tile.m_animation_id, (std::numeric_limits<std::uint8_t>::max)()));
+    };
+
+    "normalized_source_tile constructs from Tile1"_test = [] {
+      Tile1 source{};
+
+      source = source.with_texture_id(3)
+                 .with_palette_id(7)
+                 .with_layer_id(2)
+                 .with_source_xy(32, 48)
+                 .with_animation_id(5)
+                 .with_animation_state(1)
+                 .with_blend_mode(BlendModeT::add)
+                 .with_blend(true)
+                 .with_depth(4)
+                 .with_draw(true);
+
+      normalized_source_tile normalized{ source };
+
+      expect(eq(normalized.m_tex_id_buffer.id(), 3U));
+      expect(eq(normalized.m_palette_id.id(), 7U));
+      expect(eq(normalized.m_layer_id.id(), 2U));
+      expect(eq(normalized.m_source_xy.x(), 32U));
+      expect(eq(normalized.m_source_xy.y(), 48U));
+      expect(eq(normalized.m_animation_id, 5U));
+      expect(eq(normalized.m_animation_state, 1U));
+      expect(eq(normalized.m_blend_mode, BlendModeT::add));
+    };
+
+    "normalized_source_tile assignment from Tile1"_test = [] {
+      Tile1 source{};
+
+      source = source.with_texture_id(9)
+                 .with_palette_id(4)
+                 .with_layer_id(1)
+                 .with_source_xy(16, 64);
+
+      normalized_source_tile normalized{};
+
+      normalized = source;
+
+      expect(eq(normalized.m_tex_id_buffer.id(), 9U));
+      expect(eq(normalized.m_palette_id.id(), 4U));
+      expect(eq(normalized.m_layer_id.id(), 1U));
+      expect(eq(normalized.m_source_xy.x(), 16U));
+      expect(eq(normalized.m_source_xy.y(), 64U));
+    };
+
+    "normalized_source_tile equality"_test = [] {
+      Tile1 source{};
+
+      source = source.with_texture_id(1)
+                 .with_palette_id(2)
+                 .with_layer_id(3)
+                 .with_source_xy(16, 32);
+
+      normalized_source_tile a{ source };
+      normalized_source_tile b{ source };
+
+      expect(eq(a, b));
+    };
+
+    "normalized_source_tile inequality"_test = [] {
+      Tile1 lhs{};
+      Tile1 rhs{};
+
+      lhs = lhs.with_texture_id(1);
+      rhs = rhs.with_texture_id(2);
+
+      normalized_source_tile a{ lhs };
+      normalized_source_tile b{ rhs };
+
+      expect(neq(a, b));
+    };
+
+    "normalized_source_animated_tile strips blend"_test = [] {
+      Tile1 source{};
+
+      source
+        = source.with_texture_id(5).with_blend(true).with_depth(2).with_draw(
+          true);
+
+      normalized_source_animated_tile animated{ source };
+
+      expect(eq(animated.m_tex_id_buffer.blend(), false));
+      expect(eq(animated.m_tex_id_buffer.id(), 5U));
+      expect(eq(animated.m_tex_id_buffer.depth(), 2U));
+      expect(eq(animated.m_tex_id_buffer.draw(), true));
+    };
+
+    "normalized_source_animated_tile preserves palette when not animated"_test
+      = [] {
+          Tile1 source{};
+
+          source = source.with_palette_id(9);
+
+          normalized_source_animated_tile animated{ source };
+
+          expect(eq(animated.m_palette_id.id(), 9U));
+        };
+
+    "normalized_source_animated_tile masks palette when animated"_test = [] {
+      Tile1 source{};
+
+      source = source.with_palette_id(4).with_animation_id(2);
+
+      normalized_source_animated_tile animated{ source };
+
+      expect(eq(
+        animated.m_palette_id.id(),
+        (std::numeric_limits<std::uint8_t>::max)()));
+    };
+
+    "normalized_source_animated_tile equality ignores blend"_test = [] {
+      Tile1 lhs{};
+      Tile1 rhs{};
+
+      lhs = lhs.with_texture_id(1).with_blend(true).with_source_xy(16, 16);
+
+      rhs = rhs.with_texture_id(1).with_blend(false).with_source_xy(16, 16);
+
+      normalized_source_animated_tile a{ lhs };
+      normalized_source_animated_tile b{ rhs };
+
+      expect(eq(a, b));
+    };
+
+    "normalized_source_animated_tile assignment"_test = [] {
+      Tile1 source{};
+
+      source = source.with_texture_id(7)
+                 .with_palette_id(3)
+                 .with_layer_id(6)
+                 .with_source_xy(48, 80);
+
+      normalized_source_animated_tile animated{};
+
+      animated = source;
+
+      expect(eq(animated.m_tex_id_buffer.id(), 7U));
+      expect(eq(animated.m_palette_id.id(), 3U));
+      expect(eq(animated.m_layer_id.id(), 6U));
+      expect(eq(animated.m_source_xy.x(), 48U));
+      expect(eq(animated.m_source_xy.y(), 80U));
+    };
+  };
+}

--- a/tests/NormalizedSourceTile.cpp
+++ b/tests/NormalizedSourceTile.cpp
@@ -96,19 +96,40 @@ int
       expect(neq(a, b));
     };
 
-    // "NormalizedSourceAnimatedTile strips blend"_test = [] {
-    //   Tile1 source{};
-    //   source = source.with_texture_id(5)
-    //              .with_blend(true)
-    //              .with_depth(2_bpp)
-    //              .with_draw(true);
-    //   NormalizedSourceAnimatedTile animated{ source };
+    "NormalizedSourceAnimatedTile strips blend"_test = [] {
+      Tile1 source{};
+      source = source.with_texture_id(5).with_blend(true);
 
-    //   expect(eq(animated.m_tex_id_buffer.blend(), false));
-    //   expect(eq(animated.m_tex_id_buffer.id(), 5U));
-    //   expect(eq(animated.m_tex_id_buffer.depth(), 2_bpp));
-    //   expect(eq(animated.m_tex_id_buffer.draw(), true));
-    // };
+      NormalizedSourceAnimatedTile animated{ source };
+
+      expect(eq(animated.m_tex_id_buffer.blend(), false));
+    };
+
+    "NormalizedSourceAnimatedTile preserves texture id"_test = [] {
+      Tile1 source{};
+      source = source.with_texture_id(5);
+
+      NormalizedSourceAnimatedTile animated{ source };
+
+      expect(eq(animated.m_tex_id_buffer.id(), 5U));
+    };
+
+    "NormalizedSourceAnimatedTile preserves depth"_test = [] {
+      constexpr auto source = Tile1{}.with_texture_id(5).with_depth(4_bpp);
+
+      NormalizedSourceAnimatedTile animated{ source };
+
+      expect(eq(animated.m_tex_id_buffer.depth(), 4_bpp));
+    };
+
+    "NormalizedSourceAnimatedTile preserves draw flag"_test = [] {
+      Tile1 source{};
+      source = source.with_texture_id(5).with_draw(true);
+
+      NormalizedSourceAnimatedTile animated{ source };
+
+      expect(eq(animated.m_tex_id_buffer.draw(), true));
+    };
 
     "NormalizedSourceAnimatedTile preserves palette when not animated"_test
       = [] {

--- a/tests/SourceTileConflicts.cpp
+++ b/tests/SourceTileConflicts.cpp
@@ -156,5 +156,62 @@ int
 
       expect(eq(after.size() + 1U, before.size()));
     };
+
+    "source_tile_conflicts calculate/reverse round trip"_test = [] {
+      for (std::uint8_t t = 0; t < source_tile_conflicts::T_SIZE; ++t) {
+        for (std::uint16_t y = 0; y < source_tile_conflicts::GRID_SIZE;
+             y += source_tile_conflicts::Y_SIZE) {
+          for (std::uint16_t x = 0; x < source_tile_conflicts::GRID_SIZE;
+               x += source_tile_conflicts::X_SIZE) {
+            const auto index = source_tile_conflicts::calculate_index(x, y, t);
+
+            const auto location = source_tile_conflicts::reverse_index(index);
+
+            expect(eq(location.x, x)) << "x mismatch for index " << index;
+
+            expect(eq(location.y, y)) << "y mismatch for index " << index;
+
+            expect(eq(location.t, t)) << "t mismatch for index " << index;
+          }
+        }
+      }
+
+      "source_tile_conflicts calculate_index produces unique indices"_test =
+        [] {
+          constexpr auto total_size = source_tile_conflicts::X_SIZE
+                                    * source_tile_conflicts::Y_SIZE
+                                    * source_tile_conflicts::T_SIZE;
+
+          std::array<bool, total_size> seen{};
+
+          std::size_t                  visited_count = 0U;
+
+          for (std::uint8_t t = 0; t < source_tile_conflicts::T_SIZE; ++t) {
+            for (std::uint16_t y = 0; y < source_tile_conflicts::GRID_SIZE;
+                 y += source_tile_conflicts::Y_SIZE) {
+              for (std::uint16_t x = 0; x < source_tile_conflicts::GRID_SIZE;
+                   x += source_tile_conflicts::X_SIZE) {
+                const auto index
+                  = source_tile_conflicts::calculate_index(x, y, t);
+
+                expect(index < total_size) << "index out of bounds: " << index;
+
+                expect(!seen[index])
+                  << "duplicate index detected: " << index << " from x=" << x
+                  << " y=" << y << " t=" << static_cast<int>(t);
+
+                seen[index] = true;
+                ++visited_count;
+              }
+            }
+          }
+
+          expect(eq(visited_count, total_size));
+
+          expect(std::ranges::all_of(seen, [](bool v) {
+            return v;
+          }));
+        };
+    };
   };
 }

--- a/tests/SourceTileConflicts.cpp
+++ b/tests/SourceTileConflicts.cpp
@@ -1,0 +1,160 @@
+// SourceTileConflicts.cpp
+
+#include <boost/ut.hpp>
+
+#define UT_source_tile_conflicts_test
+
+#include "open_viii/graphics/background/SourceTileConflicts.hpp"
+#include "open_viii/graphics/background/Tile1.hpp"
+
+#include <ranges>
+#include <vector>
+
+int
+  main()
+{
+  using namespace boost::ut;
+  using namespace boost::ut::literals;
+  using namespace boost::ut::operators::terse;
+
+  using namespace open_viii::graphics::background;
+
+  [[maybe_unused]] suite tests = [] {
+    "source_tile_conflicts default empty state"_test = [] {
+      source_tile_conflicts conflicts{};
+
+      const auto            occupied = conflicts.range_of_occupied_locations()
+                                     | std::ranges::to<std::vector>();
+
+      const auto conflict_range      = conflicts.range_of_conflicts_flattened();
+
+      expect(occupied.empty());
+      expect(conflict_range.empty());
+    };
+
+    "source_tile_conflicts tracks occupied tile"_test = [] {
+      source_tile_conflicts conflicts{};
+
+      Tile1                 tile{};
+
+      tile = tile.with_texture_id(1).with_source_xy(16, 32);
+
+      conflicts(tile).push_back(0);
+
+      const auto occupied = conflicts.range_of_occupied_locations()
+                          | std::ranges::to<std::vector>();
+
+      expect(eq(occupied.size(), 1U));
+
+      expect(eq(occupied.front().x, 16U));
+      expect(eq(occupied.front().y, 32U));
+      expect(eq(occupied.front().t, 1U));
+    };
+
+    "source_tile_conflicts detects conflicts"_test = [] {
+      source_tile_conflicts conflicts{};
+
+      Tile1                 tile{};
+
+      tile = tile.with_texture_id(2).with_source_xy(32, 48);
+
+      conflicts(tile).push_back(1);
+      conflicts(tile).push_back(2);
+
+      const auto flattened = conflicts.range_of_conflicts_flattened();
+
+      expect(eq(flattened.size(), 2U));
+      expect(eq(flattened[0], 1));
+      expect(eq(flattened[1], 2));
+    };
+
+    "source_tile_conflicts separates texture pages"_test = [] {
+      source_tile_conflicts conflicts{};
+
+      Tile1                 a{};
+      Tile1                 b{};
+
+      a = a.with_texture_id(0).with_source_xy(16, 16);
+
+      b = b.with_texture_id(1).with_source_xy(16, 16);
+
+      conflicts(a).push_back(10);
+      conflicts(b).push_back(20);
+
+      const auto flattened = conflicts.range_of_conflicts_flattened();
+
+      expect(flattened.empty());
+
+      const auto occupied = conflicts.range_of_occupied_locations()
+                          | std::ranges::to<std::vector>();
+
+      expect(eq(occupied.size(), 2U));
+    };
+
+    "source_tile_conflicts non conflicts flattened"_test = [] {
+      source_tile_conflicts conflicts{};
+
+      Tile1                 a{};
+      Tile1                 b{};
+
+      a = a.with_texture_id(0).with_source_xy(0, 0);
+
+      b = b.with_texture_id(0).with_source_xy(16, 0);
+
+      conflicts(a).push_back(3);
+      conflicts(b).push_back(4);
+
+      const auto non_conflicts = conflicts.range_of_non_conflicts_flattened()
+                               | std::ranges::to<std::vector>();
+
+      expect(eq(non_conflicts.size(), 2U));
+      expect(eq(non_conflicts[0], 3));
+      expect(eq(non_conflicts[1], 4));
+    };
+
+    "source_tile_conflicts operator access by coordinates"_test = [] {
+      source_tile_conflicts conflicts{};
+
+      conflicts(16, 32, 1).push_back(99);
+
+      expect(eq(conflicts(16, 32, 1).size(), 1U));
+      expect(eq(conflicts(16, 32, 1).front(), 99));
+    };
+
+    "source_tile_conflicts multiple conflicts stay grouped"_test = [] {
+      source_tile_conflicts conflicts{};
+
+      Tile1                 tile{};
+
+      tile = tile.with_texture_id(3).with_source_xy(48, 48);
+
+      conflicts(tile).push_back(1);
+      conflicts(tile).push_back(2);
+      conflicts(tile).push_back(3);
+
+      const auto grouped
+        = conflicts.range_of_conflicts() | std::ranges::to<std::vector>();
+
+      expect(eq(grouped.size(), 1U));
+      expect(eq(grouped.front().size(), 3U));
+    };
+
+    "source_tile_conflicts empty locations shrink after insert"_test = [] {
+      source_tile_conflicts conflicts{};
+
+      const auto            before
+        = conflicts.range_of_empty_locations() | std::ranges::to<std::vector>();
+
+      Tile1 tile{};
+
+      tile = tile.with_texture_id(0).with_source_xy(0, 0);
+
+      conflicts(tile).push_back(1);
+
+      const auto after
+        = conflicts.range_of_empty_locations() | std::ranges::to<std::vector>();
+
+      expect(eq(after.size() + 1U, before.size()));
+    };
+  };
+}


### PR DESCRIPTION
## Summary

This PR refactors the normalized background tile types, improves formatting/logging support, fixes an index boundary assertion, and expands test coverage.

## Changes

Move tile normalization and source conflict utilities from the
downstream field-map-editor project into open_viii.

Adds:
- normalized_source_tile
- normalized_source_animated_tile
- source_tile_conflicts

Includes helpers for:
- tile deduplication/comparison
- animation-aware normalization
- conflict detection by texture/source location
- occupied/empty/conflicting tile queries

### Normalized tile refactor

Renamed:
- `normalized_source_tile` → `NormalizedSourceTile`
- `normalized_source_animated_tile` → `NormalizedSourceAnimatedTile`

Updated constructors, assignment operators, and formatting to follow the newer type naming/style conventions.

### Formatting and stream support

Added:
- `fmt::formatter` specializations for:
  - `NormalizedSourceTile`
  - `NormalizedSourceAnimatedTile`
- `std::ostream` operators for:
  - normalized tile types
  - `BlendModeT`

This allows tiles and blend modes to be logged/debugged consistently through both `fmt` and stream APIs.

### BlendModeT build integration

Added:
- `background/BlendModeT.cpp`

and registered it in the graphics CMake target.

### Animated tile palette handling

Clarified and preserved the sentinel palette behavior for animated tiles:
- animated tiles mask the palette field to the packed sentinel value when animation IDs are present
- non-animated tiles preserve the original palette ID

### SourceTileConflicts fix

Fixed an assertion in `reverse_index`:

```cpp
std::cmp_greater(index, 0)
```

became:

```cpp
std::cmp_greater_equal(index, 0)
```

This allows index `0`, which is a valid index.

## Test coverage

Expanded tests for:
- normalized tile construction
- assignment behavior
- equality semantics
- animated tile palette masking
- calculate/reverse index round trips
- uniqueness of generated indices

Additional animated tile coverage was added by splitting the previous combined
"strip blend" test into smaller focused tests covering:

- blend stripping
- texture ID preservation
- depth preservation
- draw flag preservation

The tests also correct an invalid `2_bpp` depth literal usage. Valid depth
values are:
- `4_bpp`
- `8_bpp`
- `16_bpp`
- `24_bpp`

Tests were also updated to use renamed types and typed depth literals.

## Notes

- Formatter output currently prints `blend_mode` numerically rather than via the enum formatter.