### PR TITLE
Add MapHistory to upstream.

### DIFF
--- a/src/open_viii/graphics/CMakeLists.txt
+++ b/src/open_viii/graphics/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(${PROJECT_NAME}_VIIIGraphics STATIC
     background/BlendModeT.cpp
     background/PupuID.cpp
     background/UniquifyPupu.cpp
+    background/MapHistory.cpp
 )
 add_subdirectory(color)
 add_subdirectory(tim)

--- a/src/open_viii/graphics/background/MapHistory.cpp
+++ b/src/open_viii/graphics/background/MapHistory.cpp
@@ -1,0 +1,798 @@
+//
+// Created by pcvii on 6/2/2022.
+//
+
+#include "MapHistory.hpp"
+#include "gui/colors.hpp"
+
+using namespace open_viii::graphics::background;
+using map_t = Map;
+
+/**
+ * @brief Namespace for Final Fantasy VIII-related functionality.
+ *
+ * The `ff_8` namespace contains utilities, classes, and functions related to
+ * handling tile data, conflicts, and other game-specific operations for Final
+ * Fantasy VIII.
+ */
+namespace ff_8 {
+
+/**
+ * @brief Calculates the Pupu IDs for the tiles in a given map.
+ *
+ * This function processes all tiles in the provided map and generates a unique
+ * `PupuID` (an unsigned 64-bit integer) for each tile. The `PupuID` is used to
+ * prevent conflicts or overlapping tiles in the unswizzled or rendered images,
+ * allowing modders to modify and re-import tiles without conflicts.
+ *
+ * The `UniquifyPupu` logic performs the following:
+ * - Initially, a `PupuID` is generated for each tile, which includes 4 offset
+ * bits.
+ * - After the initial generation, a second pass is made where overlapping tiles
+ * are detected.
+ * - For overlapping tiles, the `PupuID` is incremented to resolve the conflict,
+ * ensuring each tile has a unique ID even when they occupy the same location.
+ *
+ * The `PupuID` is designed to wrap around the unsigned 64-bit integer, allowing
+ * you to reverse the ID back to the original values, much like
+ * `SourceTileConflicts` handles the swizzle or input locations.
+ *
+ * The generated `PupuID`s can be used to:
+ * - Dump unswizzled images with unique filenames containing the raw hex value
+ * of each `PupuID`.
+ * - Allow modders to upscale or modify the images.
+ * - Re-import the modified images back into the system without conflicts.
+ *
+ * @param map The map containing the tiles to process.
+ * @return A vector of `PupuID` objects corresponding to the tiles in the map.
+ */
+static std::vector<PupuID>
+  calculate_pupu(const map_t &map)
+{
+  return map.visit_tiles([](const auto &tiles) {
+    std::vector<PupuID> pupu_ids = {};
+    UniquifyPupu const  pupu_map = {};
+    pupu_ids.reserve(std::ranges::size(tiles));
+
+    std::ranges::transform(
+      tiles | Map::filter_view_invalid(),
+      std::back_insert_iterator(pupu_ids),
+      pupu_map);
+    return pupu_ids;
+  });
+}
+
+/**
+ * @brief Generates a vector of unique PupuIDs from the input vector.
+ *
+ * This function processes a vector of `PupuID` values, removing any duplicate
+ * entries while preserving the order of unique elements (after sorting). The
+ * steps include:
+ * - Sorting the input vector to group duplicates together.
+ * - Removing consecutive duplicates using `std::ranges::unique`.
+ * - Erasing the duplicates from the resulting vector to ensure all elements are
+ * unique.
+ *
+ * @param input A vector of `PupuID` values that may contain duplicates.
+ * @return A new vector containing only the unique `PupuID` values from the
+ * input.
+ *
+ * @note The function operates on a copy of the input, leaving the original
+ * vector unmodified. The output is sorted due to the use of `std::ranges::sort`
+ * prior to deduplication.
+ */
+static std::vector<PupuID>
+  make_unique_pupu(const std::vector<PupuID> &input)
+{
+  // Copies the input
+  std::vector<PupuID> output = input;
+
+  // Sorts the vector to prepare for unique removal
+  std::ranges::sort(output);
+
+  // Removes consecutive duplicates
+  const auto last = std::ranges::unique(output);
+
+  // Erases the duplicates from the vector
+  output.erase(last.begin(), last.end());
+  return output;
+}
+
+/**
+ * @brief Calculates source tile location conflicts for a given map.
+ *
+ * This function identifies and tracks conflicts between tiles in the provided
+ * map. A conflict is defined as multiple tiles occupying the same grid
+ * location. The result is a `SourceTileConflicts` object, which stores
+ * information about conflicting tiles and their locations.
+ *
+ * @param map The map containing the tiles to process.
+ * @return A `SourceTileConflicts` object representing the tile conflicts in
+ * the map.
+ */
+[[nodiscard]] static SourceTileConflicts
+  calculate_conflicts(const map_t &map)
+{
+  return map.visit_tiles([](const auto &tiles) {
+    SourceTileConflicts stc{};
+    std::ranges::for_each(
+      tiles | Map::filter_view_invalid(),
+      [&](const auto &tile) {
+        stc(tile).push_back(std::ranges::distance(&tiles.front(), &tile));
+      });
+    return stc;
+  });
+}
+
+/**
+ * @brief Populates a map with the count of similar tiles within a given range
+ * of tile indices.
+ *
+ * This function traverses a range of tile indices within the map and counts the
+ * frequency of normalized tiles. The function returns a map where each key is a
+ * normalized tile, and the corresponding value is the count of its occurrences
+ * within the specified range of tile indices.
+ *
+ * The count of tiles is incremented for each occurrence of a normalized tile in
+ * the provided range. This is useful for identifying tiles that appear multiple
+ * times in the range, potentially for highlighting or providing additional
+ * feedback to the user.
+ *
+ * @param map The map object that contains the tiles to be processed.
+ * @param range_of_tile_indices A range of indices specifying the tiles to be
+ * counted. The range can be any iterable sequence of indices that corresponds
+ * to the tiles within the map.
+ *
+ * @return A map of `NormalizedSourceTile` to `std::uint8_t` where the key is
+ * the normalized tile and the value is the count of its occurrences within the
+ * specified range of tile indices.
+ *
+ * @note This function relies on `std::ranges::advance` to retrieve the tile at
+ * each index, ensuring that the correct tile is processed for each index in the
+ * given range.
+ */
+[[nodiscard]] static std::map<NormalizedSourceTile, std::uint8_t>
+  populate_similar_tile_count(
+    const map_t              &map,
+    std::ranges::range auto &&range_of_tile_indices)
+{
+
+  return map.visit_tiles([&](const auto &tiles) {
+    std::map<NormalizedSourceTile, std::uint8_t> ret = {};
+    const auto to_tile                               = [&](const auto index) {
+      assert(
+        std::cmp_less(index, std::ranges::size(tiles))
+        && "index out of range!");
+      auto begin = std::ranges::cbegin(tiles);
+      std::ranges::advance(begin, index);
+      return *begin;
+    };
+    auto transform_view
+      = range_of_tile_indices | std::ranges::views::transform(to_tile);
+    for (const auto tile :
+         transform_view) {// Increment the count for the current tile (default
+                          // initializes to 0 if not found)
+      ++ret[tile];
+    }
+    return ret;
+  });
+}
+
+/**
+ * @brief Populates a map with the count of animated tiles within a given range
+ * of tile indices.
+ *
+ * This function processes a range of tile indices within the map and counts the
+ * frequency of normalized animated tiles. The result is a map where each key is
+ * a `normalized_source_animated_tile`, and the corresponding value represents
+ * the count of its occurrences in the specified range.
+ *
+ * This function is useful for identifying frequently used animated tiles within
+ * the range, which may help with optimization, debugging, or providing visual
+ * feedback to users.
+ *
+ * @param map The map object containing tiles to process.
+ * @param range_of_tile_indices A range of indices specifying the animated tiles
+ * to be counted. The range can be any iterable sequence of indices
+ * corresponding to tiles in the map.
+ *
+ * @return A map of `normalized_source_animated_tile` to `std::uint8_t` where
+ * the key is the normalized animated tile and the value is the count of its
+ * occurrences within the specified range of tile indices.
+ *
+ * @note This function ensures that tile indices are within bounds using an
+ * `assert` statement. It leverages `std::ranges` to transform the range of
+ * indices into tiles and count their occurrences.
+ */
+[[nodiscard]] static std::map<normalized_source_animated_tile, std::uint8_t>
+  populate_animation_tile_count(
+    const map_t              &map,
+    std::ranges::range auto &&range_of_tile_indices)
+{
+
+  return map.visit_tiles([&](const auto &tiles) {
+    std::map<normalized_source_animated_tile, std::uint8_t> ret = {};
+    const auto to_tile = [&](const auto index) {
+      assert(
+        std::cmp_less(index, std::ranges::size(tiles))
+        && "index out of range!");
+      auto begin = std::ranges::cbegin(tiles);
+      std::ranges::advance(begin, index);
+      return *begin;
+    };
+    auto transform_view
+      = range_of_tile_indices | std::ranges::views::transform(to_tile);
+    for (const auto &tile :
+         transform_view) {// Increment the count for the current tile (default
+                          // initializes to 0 if not found)
+      ++ret[tile];
+    }
+    return ret;
+  });
+}
+
+// /**
+//  * @brief Generates a map of normalized source animated tiles to their counts
+//  based on similar tiles.
+//  *
+//  * This function processes a subset of tiles (`similar_tiles`) and creates a
+//  new map where
+//  * each normalized source animated tile is associated with its total count.
+//  It aggregates counts
+//  * from the given similar tiles map.
+//  *
+//  * @param similar_tiles A map containing normalized source tiles and their
+//  counts.
+//  * @return A map of normalized source animated tiles to their total counts.
+//  */
+// [[nodiscard]] static std::map<normalized_source_animated_tile, std::uint8_t>
+//   populate_animation_tile_count(const ff_8::MapHistory::nst_map
+//   &similar_tiles)
+// {
+//      std::map<normalized_source_animated_tile, std::uint8_t> ret = {};
+//      for (const auto &[tile, count] : similar_tiles)
+//      {
+//           ret[tile] += count;
+//      }
+//      return ret;
+// }
+
+/**
+ * @brief Disambiguates conflicts between similar and animation tile counts.
+ *
+ * This function ensures that tiles are either marked as similar or animation
+ * tiles, but not both. It resolves conflicts by prioritizing one category over
+ * the other:
+ * - If a tile's "similar" count is greater than 1, its animation count is set
+ * to 0, as similar tiles are considered more specific.
+ * - Otherwise, the "similar" count is set to 0, prioritizing animation tiles.
+ *
+ * The function assumes that the number of elements in `working_similar_counts`
+ * is greater than or equal to the number of elements in
+ * `working_animation_counts`. It uses the key from `working_similar_counts` to
+ * access and modify corresponding values in `working_animation_counts`.
+ *
+ * @param working_similar_counts A reference to a map of normalized source tiles
+ * and their similar counts. This map must have a superset of the keys in
+ * `working_animation_counts`.
+ * @param working_animation_counts A reference to a map of normalized source
+ * animated tiles and their counts. Keys in this map may be a subset of those in
+ * `working_similar_counts`.
+ *
+ * @note This function uses an `assert` to ensure that the size of
+ * `working_similar_counts` is greater than or equal to the size of
+ * `working_animation_counts`.
+ */
+static void
+  disambiguate_normalized_tiles(
+    ff_8::MapHistory::nst_map  &working_similar_counts,
+    ff_8::MapHistory::nsat_map &working_animation_counts)
+{
+  assert(
+    std::cmp_greater_equal(
+      std::ranges::size(working_similar_counts),
+      std::ranges::size(working_animation_counts)));
+  std::ranges::for_each(working_similar_counts, [&](auto &similar) {
+    if (
+      std::cmp_equal(
+        similar.first.m_animation_id,
+        (std::numeric_limits<std::uint8_t>::max)())) {
+      if (similar.second > 1) {
+        auto &animated = working_animation_counts[similar.first];
+        animated       = 0;// similar is more specific
+      }
+      else {
+        similar.second = 0;// assume animation is more important
+      }
+      return;
+    }
+
+    similar.second = 0;// assume animation is more important
+  });
+}
+
+static std::vector<glm::vec4>
+  create_colors_from_indexes(std::size_t count)
+{
+  return std::views::iota(0u, static_cast<std::uint32_t>(count))
+       | std::views::transform([&](const auto index) {
+           return fme::colors::encode_uint_to_rgba(
+             static_cast<std::uint32_t>(index));
+         })
+       | std::ranges::to<std::vector>();
+}
+
+}// namespace ff_8
+
+ff_8::MapHistory::MapHistory(map_t map)
+  : m_original(std::move(map)), m_working(m_original),
+    m_original_pupu(calculate_pupu(m_original)),
+    m_working_pupu(m_original_pupu),
+    m_original_unique_pupu(make_unique_pupu(m_original_pupu)),
+    m_working_unique_pupu(m_original_unique_pupu),
+    m_original_unique_pupu_color(
+      create_colors_from_indexes(std::ranges::size(m_original_unique_pupu))),
+    m_working_unique_pupu_color(m_original_unique_pupu_color),
+    m_original_conflicts(calculate_conflicts(m_original)),
+    m_working_conflicts(calculate_conflicts(m_original)),
+    m_working_similar_counts(populate_similar_tile_count(
+      m_working,
+      m_working_conflicts.range_of_conflicts_flattened())),
+    m_working_animation_counts(populate_animation_tile_count(
+      m_working,
+      m_working_conflicts.range_of_conflicts_flattened()))
+{
+  disambiguate_normalized_tiles(
+    m_working_similar_counts,
+    m_working_animation_counts);
+}
+
+void
+  ff_8::MapHistory::refresh_original_all(bool force) const
+{
+  if (!m_original_changed && !force) {
+    return;
+  }
+  refresh_original_pupu();
+  refresh_original_conflicts();
+  m_original_changed = false;
+}
+
+void
+  ff_8::MapHistory::refresh_working_all(bool force) const
+{
+  if (!m_working_changed && !force) {
+    return;
+  }
+  refresh_working_conflicts();
+  refresh_working_pupu();
+  m_working_changed = false;
+}
+
+void
+  ff_8::MapHistory::refresh_original_pupu() const
+{
+  m_original_pupu        = calculate_pupu(m_original);
+  m_original_unique_pupu = make_unique_pupu(m_original_pupu);
+  if (
+    std::ranges::size(m_original_unique_pupu)
+    != std::ranges::size(m_original_unique_pupu_color)) {
+    m_original_unique_pupu_color
+      = create_colors_from_indexes(std::ranges::size(m_original_unique_pupu));
+  }
+}
+
+void
+  ff_8::MapHistory::refresh_working_pupu() const
+{
+  m_working_pupu        = calculate_pupu(m_working);
+  m_working_unique_pupu = make_unique_pupu(m_working_pupu);
+  if (
+    std::ranges::size(m_original_unique_pupu)
+    != std::ranges::size(m_working_unique_pupu_color)) {
+    m_working_unique_pupu_color
+      = create_colors_from_indexes(std::ranges::size(m_working_unique_pupu));
+  }
+}
+
+void
+  ff_8::MapHistory::refresh_original_conflicts() const
+{
+  m_original_conflicts = calculate_conflicts(m_original);
+}
+
+void
+  ff_8::MapHistory::refresh_working_conflicts() const
+{
+  m_working_conflicts      = calculate_conflicts(m_working);
+  m_working_similar_counts = populate_similar_tile_count(
+    m_working,
+    m_working_conflicts.range_of_conflicts_flattened());
+  m_working_animation_counts = populate_animation_tile_count(
+    m_working,
+    m_working_conflicts.range_of_conflicts_flattened());
+  disambiguate_normalized_tiles(
+    m_working_similar_counts,
+    m_working_animation_counts);
+}
+
+const std::vector<ff_8::PupuID> &
+  ff_8::MapHistory::original_pupu() const noexcept
+{
+  return m_original_pupu;
+}
+
+const std::vector<ff_8::PupuID> &
+  ff_8::MapHistory::working_pupu() const noexcept
+{
+  return m_working_pupu;
+}
+
+const std::vector<ff_8::PupuID> &
+  ff_8::MapHistory::original_unique_pupu() const noexcept
+{
+  return m_original_unique_pupu;
+}
+
+const std::vector<ff_8::PupuID> &
+  ff_8::MapHistory::working_unique_pupu() const noexcept
+{
+  return m_working_unique_pupu;
+}
+
+const std::vector<glm::vec4> &
+  ff_8::MapHistory::original_unique_pupu_color() const noexcept
+{
+  return m_original_unique_pupu_color;
+}
+
+const std::vector<glm::vec4> &
+  ff_8::MapHistory::working_unique_pupu_color() const noexcept
+{
+  return m_working_unique_pupu_color;
+}
+
+const ff_8::SourceTileConflicts &
+  ff_8::MapHistory::original_conflicts() const noexcept
+{
+  return m_original_conflicts;
+}
+
+const ff_8::SourceTileConflicts &
+  ff_8::MapHistory::working_conflicts() const noexcept
+{
+  return m_working_conflicts;
+}
+
+const ff_8::MapHistory::nst_map &
+  ff_8::MapHistory::working_similar_counts() const noexcept
+{
+  return m_working_similar_counts;
+}
+
+const ff_8::MapHistory::nsat_map &
+  ff_8::MapHistory::working_animation_counts() const noexcept
+{
+  return m_working_animation_counts;
+}
+
+std::size_t
+  ff_8::MapHistory::count() const
+{
+  return m_undo_history.size();
+}
+
+std::size_t
+  ff_8::MapHistory::redo_count() const
+{
+  return m_redo_history.size();
+}
+
+const map_t &
+  ff_8::MapHistory::original() const
+{
+  return m_original;
+}
+
+map_t &
+  ff_8::MapHistory::original_mutable()
+{
+  return m_original;
+}
+
+map_t &
+  ff_8::MapHistory::working()
+{
+  return m_working;
+}
+
+const map_t &
+  ff_8::MapHistory::working() const
+{
+  return m_working;
+}
+
+map_t &
+  ff_8::MapHistory::copy_original(std::string description)
+{
+  if (m_in_multi_frame_operation) {
+    return original_mutable();
+  }
+  (void)debug_count_print();
+  clear_redo();
+  m_undo_original_or_working.push_back(pushed::original);
+  m_undo_history.push_back(original());
+  m_undo_change_descriptions.push_back(std::move(description));
+  m_original_changed = true;
+  return original_mutable();
+}
+
+map_t &
+  ff_8::MapHistory::copy_working(std::string description)
+{
+  if (m_in_multi_frame_operation) {
+    return working();
+  }
+  (void)debug_count_print();
+  clear_redo();
+  m_undo_original_or_working.push_back(pushed::working);
+  m_undo_history.push_back(working());
+  m_undo_change_descriptions.push_back(std::move(description));
+  m_working_changed = true;
+  return working();
+}
+
+map_t &
+  ff_8::MapHistory::begin_multi_frame_working(std::string description)
+{
+  if (!m_in_multi_frame_operation) {
+    const auto pop_set = glengine::ScopeGuard{ [this] {
+      m_in_multi_frame_operation = true;
+    } };
+    return copy_working(std::move(description));
+  }
+  return working();
+}
+
+void
+  ff_8::MapHistory::end_multi_frame_working(std::string description)
+{
+  m_in_multi_frame_operation = false;
+  if (!description.empty() && !m_undo_change_descriptions.empty()) {
+    m_undo_change_descriptions.back() = std::move(description);
+  }
+  m_working_changed = true;
+  // if nothing changes remove undo till there are no matches.
+  std::ignore       = remove_duplicate();
+}
+
+void
+  ff_8::MapHistory::clear_redo()
+{
+  m_redo_history.clear();
+  m_redo_original_or_working.clear();
+}
+
+bool
+  ff_8::MapHistory::remove_duplicate()
+{
+  bool ret = false;
+  while (undo_enabled() &&
+         ((m_undo_original_or_working.back() == pushed::working
+           && m_undo_history.back() == m_working)
+          || (m_undo_original_or_working.back() == pushed::original
+              && m_undo_history.back() == m_original)))
+     {
+    (void)undo(true);
+    ret = true;
+  }
+  return ret;
+}
+
+const map_t &
+  ff_8::MapHistory::first_to_original(std::string description)
+{
+  (void)debug_count_print();
+  clear_redo();
+  m_undo_history.push_back(original());
+  m_undo_original_or_working.push_back(pushed::original);
+  m_undo_change_descriptions.push_back(std::move(description));
+  m_original         = m_undo_history.front();
+  m_original_changed = true;
+  return original();
+}
+
+const map_t &
+  ff_8::MapHistory::first_to_working(std::string description)
+{
+  (void)debug_count_print();
+  clear_redo();
+  m_undo_history.push_back(working());
+  m_undo_original_or_working.push_back(pushed::working);
+  m_undo_change_descriptions.push_back(std::move(description));
+  m_working         = m_undo_history.front();
+  m_working_changed = true;
+  return working();
+}
+
+const map_t &
+  ff_8::MapHistory::copy_working_to_original(std::string description)
+{
+  (void)debug_count_print();
+  clear_redo();
+  m_undo_history.push_back(original());
+  m_undo_original_or_working.push_back(pushed::original);
+  m_undo_change_descriptions.push_back(std::move(description));
+  // todo do we want to recalculate the pupu?
+  m_original         = working();
+  m_original_changed = true;
+  return original();
+}
+
+bool
+  ff_8::MapHistory::redo()
+{
+  const auto count = debug_count_print();
+  if (!redo_enabled()) {
+    return false;
+  }
+  const pushed last = m_redo_original_or_working.back();
+  m_undo_original_or_working.push_back(last);
+  m_redo_original_or_working.pop_back();
+
+  (void)m_undo_change_descriptions.emplace_back(
+    std::move(m_redo_change_descriptions.back()));
+  m_redo_change_descriptions.pop_back();
+  if (last == pushed::working) {
+    (void)m_undo_history.emplace_back(std::move(m_working));
+    m_working         = std::move(m_redo_history.back());
+    m_working_changed = true;
+    m_redo_history.pop_back();
+    return true;
+  }
+  (void)m_undo_history.emplace_back(std::move(m_original));
+  m_original         = std::move(m_redo_history.back());
+  m_original_changed = true;
+  m_redo_history.pop_back();
+  return true;
+}
+
+bool
+  ff_8::MapHistory::undo(bool skip_redo)
+{
+  const auto count = debug_count_print();
+  if (!undo_enabled()) {
+    return false;
+  }
+  const pushed last = m_undo_original_or_working.back();
+  if (!skip_redo) {
+    m_redo_original_or_working.push_back(last);
+    (void)m_redo_change_descriptions.emplace_back(
+      std::move(m_undo_change_descriptions.back()));
+  }
+  m_undo_original_or_working.pop_back();
+  m_undo_change_descriptions.pop_back();
+  if (last == pushed::working) {
+    if (!skip_redo) {
+      m_redo_history.emplace_back(std::move(m_working));
+    }
+    m_working         = std::move(m_undo_history.back());
+    m_working_changed = true;
+    m_undo_history.pop_back();
+    return true;
+  }
+  if (!skip_redo) {
+    m_redo_history.emplace_back(std::move(m_original));
+  }
+  m_original         = std::move(m_undo_history.back());
+  m_original_changed = true;
+  m_undo_history.pop_back();
+  return true;
+}
+void
+  ff_8::MapHistory::undo_all()
+{
+  while (undo()) {}
+}
+void
+  ff_8::MapHistory::redo_all()
+{
+  while (redo()) {}
+}
+bool
+  ff_8::MapHistory::redo_enabled() const
+{
+  return !std::ranges::empty(m_redo_history)
+      && !std::ranges::empty(m_redo_original_or_working);
+}
+
+bool
+  ff_8::MapHistory::undo_enabled() const
+{
+  return !std::ranges::empty(m_undo_history)
+      && !std::ranges::empty(m_undo_original_or_working);
+}
+
+const map_t &
+  ff_8::MapHistory::const_working() const
+{
+  return m_working;
+}
+
+template<is_tile TileT>
+[[nodiscard]] ff_8::PupuID
+  ff_8::MapHistory::get_pupu_from_working(const TileT &tile) const
+{
+  return m_original_pupu[static_cast<std::size_t>(
+    get_offset_from_working(tile))];
+}
+
+// Explicit instantiation for Tiles
+template ff_8::PupuID
+  ff_8::MapHistory::get_pupu_from_working(const Tile1 &) const;
+template ff_8::PupuID
+  ff_8::MapHistory::get_pupu_from_working(const Tile2 &) const;
+template ff_8::PupuID
+  ff_8::MapHistory::get_pupu_from_working(const Tile3 &) const;
+
+template<open_viii::graphics::background::is_tile TileT>
+std::vector<TileT>::difference_type
+  ff_8::MapHistory::get_offset_from_working(const TileT &tile) const
+{
+  return working().visit_tiles(
+    [&](const auto &tiles) -> std::vector<TileT>::difference_type {
+      if constexpr (
+        std::is_same_v<
+          std::ranges::range_value_t<std::remove_cvref_t<decltype(tiles)>>,
+          TileT>) {
+        return static_cast<std::vector<TileT>::difference_type>(
+          std::ranges::distance(&tiles.front(), &tile));
+      }
+      else {
+        return {};
+      }
+    });
+}
+
+template std::vector<Tile1>::difference_type
+  ff_8::MapHistory::get_offset_from_working(const Tile1 &) const;
+template std::vector<Tile2>::difference_type
+  ff_8::MapHistory::get_offset_from_working(const Tile2 &) const;
+template std::vector<Tile3>::difference_type
+  ff_8::MapHistory::get_offset_from_working(const Tile3 &) const;
+
+std::string_view
+  ff_8::MapHistory::current_undo_description() const
+{
+  if (std::ranges::empty(m_undo_change_descriptions)) {
+    return {};
+  }
+  return m_undo_change_descriptions.back();
+}
+
+std::string_view
+  ff_8::MapHistory::current_redo_description() const
+{
+  if (std::ranges::empty(m_redo_change_descriptions)) {
+    return {};
+  }
+  return m_redo_change_descriptions.back();
+}
+
+[[nodiscard]] ff_8::MapHistory::pushed
+  ff_8::MapHistory::current_undo_pushed() const
+{
+  if (std::ranges::empty(m_undo_original_or_working)) {
+    return {};
+  }
+  return m_undo_original_or_working.back();
+}
+
+[[nodiscard]] ff_8::MapHistory::pushed
+  ff_8::MapHistory::current_redo_pushed() const
+{
+  if (std::ranges::empty(m_redo_original_or_working)) {
+    return {};
+  }
+  return m_redo_original_or_working.back();
+}

--- a/src/open_viii/graphics/background/MapHistory.cpp
+++ b/src/open_viii/graphics/background/MapHistory.cpp
@@ -3,38 +3,30 @@
 //
 
 #include "MapHistory.hpp"
-#include "gui/colors.hpp"
-
-using namespace open_viii::graphics::background;
+// #include "gui/colors.hpp"
+namespace open_viii::graphics::background {
 using map_t = Map;
-
-/**
- * @brief Namespace for Final Fantasy VIII-related functionality.
- *
- * The `ff_8` namespace contains utilities, classes, and functions related to
- * handling tile data, conflicts, and other game-specific operations for Final
- * Fantasy VIII.
- */
-namespace ff_8 {
 
 /**
  * @brief Calculates the Pupu IDs for the tiles in a given map.
  *
- * This function processes all tiles in the provided map and generates a unique
- * `PupuID` (an unsigned 64-bit integer) for each tile. The `PupuID` is used to
- * prevent conflicts or overlapping tiles in the unswizzled or rendered images,
- * allowing modders to modify and re-import tiles without conflicts.
+ * This function processes all tiles in the provided map and generates a
+ * unique `PupuID` (an unsigned 64-bit integer) for each tile. The `PupuID` is
+ * used to prevent conflicts or overlapping tiles in the unswizzled or
+ * rendered images, allowing modders to modify and re-import tiles without
+ * conflicts.
  *
  * The `UniquifyPupu` logic performs the following:
  * - Initially, a `PupuID` is generated for each tile, which includes 4 offset
  * bits.
- * - After the initial generation, a second pass is made where overlapping tiles
- * are detected.
- * - For overlapping tiles, the `PupuID` is incremented to resolve the conflict,
- * ensuring each tile has a unique ID even when they occupy the same location.
+ * - After the initial generation, a second pass is made where overlapping
+ * tiles are detected.
+ * - For overlapping tiles, the `PupuID` is incremented to resolve the
+ * conflict, ensuring each tile has a unique ID even when they occupy the same
+ * location.
  *
- * The `PupuID` is designed to wrap around the unsigned 64-bit integer, allowing
- * you to reverse the ID back to the original values, much like
+ * The `PupuID` is designed to wrap around the unsigned 64-bit integer,
+ * allowing you to reverse the ID back to the original values, much like
  * `SourceTileConflicts` handles the swizzle or input locations.
  *
  * The generated `PupuID`s can be used to:
@@ -70,16 +62,16 @@ static std::vector<PupuID>
  * steps include:
  * - Sorting the input vector to group duplicates together.
  * - Removing consecutive duplicates using `std::ranges::unique`.
- * - Erasing the duplicates from the resulting vector to ensure all elements are
- * unique.
+ * - Erasing the duplicates from the resulting vector to ensure all elements
+ * are unique.
  *
  * @param input A vector of `PupuID` values that may contain duplicates.
  * @return A new vector containing only the unique `PupuID` values from the
  * input.
  *
  * @note The function operates on a copy of the input, leaving the original
- * vector unmodified. The output is sorted due to the use of `std::ranges::sort`
- * prior to deduplication.
+ * vector unmodified. The output is sorted due to the use of
+ * `std::ranges::sort` prior to deduplication.
  */
 static std::vector<PupuID>
   make_unique_pupu(const std::vector<PupuID> &input)
@@ -128,15 +120,15 @@ static std::vector<PupuID>
  * @brief Populates a map with the count of similar tiles within a given range
  * of tile indices.
  *
- * This function traverses a range of tile indices within the map and counts the
- * frequency of normalized tiles. The function returns a map where each key is a
- * normalized tile, and the corresponding value is the count of its occurrences
- * within the specified range of tile indices.
+ * This function traverses a range of tile indices within the map and counts
+ * the frequency of normalized tiles. The function returns a map where each
+ * key is a normalized tile, and the corresponding value is the count of its
+ * occurrences within the specified range of tile indices.
  *
- * The count of tiles is incremented for each occurrence of a normalized tile in
- * the provided range. This is useful for identifying tiles that appear multiple
- * times in the range, potentially for highlighting or providing additional
- * feedback to the user.
+ * The count of tiles is incremented for each occurrence of a normalized tile
+ * in the provided range. This is useful for identifying tiles that appear
+ * multiple times in the range, potentially for highlighting or providing
+ * additional feedback to the user.
  *
  * @param map The map object that contains the tiles to be processed.
  * @param range_of_tile_indices A range of indices specifying the tiles to be
@@ -144,12 +136,12 @@ static std::vector<PupuID>
  * to the tiles within the map.
  *
  * @return A map of `NormalizedSourceTile` to `std::uint8_t` where the key is
- * the normalized tile and the value is the count of its occurrences within the
- * specified range of tile indices.
+ * the normalized tile and the value is the count of its occurrences within
+ * the specified range of tile indices.
  *
- * @note This function relies on `std::ranges::advance` to retrieve the tile at
- * each index, ensuring that the correct tile is processed for each index in the
- * given range.
+ * @note This function relies on `std::ranges::advance` to retrieve the tile
+ * at each index, ensuring that the correct tile is processed for each index
+ * in the given range.
  */
 [[nodiscard]] static std::map<NormalizedSourceTile, std::uint8_t>
   populate_similar_tile_count(
@@ -179,24 +171,24 @@ static std::vector<PupuID>
 }
 
 /**
- * @brief Populates a map with the count of animated tiles within a given range
- * of tile indices.
+ * @brief Populates a map with the count of animated tiles within a given
+ * range of tile indices.
  *
- * This function processes a range of tile indices within the map and counts the
- * frequency of normalized animated tiles. The result is a map where each key is
- * a `normalized_source_animated_tile`, and the corresponding value represents
- * the count of its occurrences in the specified range.
+ * This function processes a range of tile indices within the map and counts
+ * the frequency of normalized animated tiles. The result is a map where each
+ * key is a `NormalizedSourceAnimatedTile`, and the corresponding value
+ * represents the count of its occurrences in the specified range.
  *
- * This function is useful for identifying frequently used animated tiles within
- * the range, which may help with optimization, debugging, or providing visual
- * feedback to users.
+ * This function is useful for identifying frequently used animated tiles
+ * within the range, which may help with optimization, debugging, or providing
+ * visual feedback to users.
  *
  * @param map The map object containing tiles to process.
- * @param range_of_tile_indices A range of indices specifying the animated tiles
- * to be counted. The range can be any iterable sequence of indices
+ * @param range_of_tile_indices A range of indices specifying the animated
+ * tiles to be counted. The range can be any iterable sequence of indices
  * corresponding to tiles in the map.
  *
- * @return A map of `normalized_source_animated_tile` to `std::uint8_t` where
+ * @return A map of `NormalizedSourceAnimatedTile` to `std::uint8_t` where
  * the key is the normalized animated tile and the value is the count of its
  * occurrences within the specified range of tile indices.
  *
@@ -204,14 +196,14 @@ static std::vector<PupuID>
  * `assert` statement. It leverages `std::ranges` to transform the range of
  * indices into tiles and count their occurrences.
  */
-[[nodiscard]] static std::map<normalized_source_animated_tile, std::uint8_t>
+[[nodiscard]] static std::map<NormalizedSourceAnimatedTile, std::uint8_t>
   populate_animation_tile_count(
     const map_t              &map,
     std::ranges::range auto &&range_of_tile_indices)
 {
 
   return map.visit_tiles([&](const auto &tiles) {
-    std::map<normalized_source_animated_tile, std::uint8_t> ret = {};
+    std::map<NormalizedSourceAnimatedTile, std::uint8_t> ret = {};
     const auto to_tile = [&](const auto index) {
       assert(
         std::cmp_less(index, std::ranges::size(tiles))
@@ -232,11 +224,11 @@ static std::vector<PupuID>
 }
 
 // /**
-//  * @brief Generates a map of normalized source animated tiles to their counts
-//  based on similar tiles.
+//  * @brief Generates a map of normalized source animated tiles to their
+//  counts based on similar tiles.
 //  *
-//  * This function processes a subset of tiles (`similar_tiles`) and creates a
-//  new map where
+//  * This function processes a subset of tiles (`similar_tiles`) and creates
+//  a new map where
 //  * each normalized source animated tile is associated with its total count.
 //  It aggregates counts
 //  * from the given similar tiles map.
@@ -245,11 +237,11 @@ static std::vector<PupuID>
 //  counts.
 //  * @return A map of normalized source animated tiles to their total counts.
 //  */
-// [[nodiscard]] static std::map<normalized_source_animated_tile, std::uint8_t>
-//   populate_animation_tile_count(const ff_8::MapHistory::nst_map
+// [[nodiscard]] static std::map<NormalizedSourceAnimatedTile, std::uint8_t>
+//   populate_animation_tile_count(const MapHistory::nst_map
 //   &similar_tiles)
 // {
-//      std::map<normalized_source_animated_tile, std::uint8_t> ret = {};
+//      std::map<NormalizedSourceAnimatedTile, std::uint8_t> ret = {};
 //      for (const auto &[tile, count] : similar_tiles)
 //      {
 //           ret[tile] += count;
@@ -261,23 +253,24 @@ static std::vector<PupuID>
  * @brief Disambiguates conflicts between similar and animation tile counts.
  *
  * This function ensures that tiles are either marked as similar or animation
- * tiles, but not both. It resolves conflicts by prioritizing one category over
- * the other:
+ * tiles, but not both. It resolves conflicts by prioritizing one category
+ * over the other:
  * - If a tile's "similar" count is greater than 1, its animation count is set
  * to 0, as similar tiles are considered more specific.
  * - Otherwise, the "similar" count is set to 0, prioritizing animation tiles.
  *
- * The function assumes that the number of elements in `working_similar_counts`
- * is greater than or equal to the number of elements in
- * `working_animation_counts`. It uses the key from `working_similar_counts` to
- * access and modify corresponding values in `working_animation_counts`.
- *
- * @param working_similar_counts A reference to a map of normalized source tiles
- * and their similar counts. This map must have a superset of the keys in
+ * The function assumes that the number of elements in
+ * `working_similar_counts` is greater than or equal to the number of elements
+ * in `working_animation_counts`. It uses the key from
+ * `working_similar_counts` to access and modify corresponding values in
  * `working_animation_counts`.
+ *
+ * @param working_similar_counts A reference to a map of normalized source
+ * tiles and their similar counts. This map must have a superset of the keys
+ * in `working_animation_counts`.
  * @param working_animation_counts A reference to a map of normalized source
- * animated tiles and their counts. Keys in this map may be a subset of those in
- * `working_similar_counts`.
+ * animated tiles and their counts. Keys in this map may be a subset of those
+ * in `working_similar_counts`.
  *
  * @note This function uses an `assert` to ensure that the size of
  * `working_similar_counts` is greater than or equal to the size of
@@ -285,8 +278,8 @@ static std::vector<PupuID>
  */
 static void
   disambiguate_normalized_tiles(
-    ff_8::MapHistory::nst_map  &working_similar_counts,
-    ff_8::MapHistory::nsat_map &working_animation_counts)
+    MapHistory::nst_map  &working_similar_counts,
+    MapHistory::nsat_map &working_animation_counts)
 {
   assert(
     std::cmp_greater_equal(
@@ -311,20 +304,18 @@ static void
   });
 }
 
-static std::vector<glm::vec4>
+static std::vector<Color32RGBA>
   create_colors_from_indexes(std::size_t count)
 {
   return std::views::iota(0u, static_cast<std::uint32_t>(count))
        | std::views::transform([&](const auto index) {
-           return fme::colors::encode_uint_to_rgba(
+           return PupuID::encode_uint_to_rgba(
              static_cast<std::uint32_t>(index));
          })
        | std::ranges::to<std::vector>();
 }
 
-}// namespace ff_8
-
-ff_8::MapHistory::MapHistory(map_t map)
+MapHistory::MapHistory(map_t map)
   : m_original(std::move(map)), m_working(m_original),
     m_original_pupu(calculate_pupu(m_original)),
     m_working_pupu(m_original_pupu),
@@ -348,7 +339,7 @@ ff_8::MapHistory::MapHistory(map_t map)
 }
 
 void
-  ff_8::MapHistory::refresh_original_all(bool force) const
+  MapHistory::refresh_original_all(bool force) const
 {
   if (!m_original_changed && !force) {
     return;
@@ -359,7 +350,7 @@ void
 }
 
 void
-  ff_8::MapHistory::refresh_working_all(bool force) const
+  MapHistory::refresh_working_all(bool force) const
 {
   if (!m_working_changed && !force) {
     return;
@@ -370,7 +361,7 @@ void
 }
 
 void
-  ff_8::MapHistory::refresh_original_pupu() const
+  MapHistory::refresh_original_pupu() const
 {
   m_original_pupu        = calculate_pupu(m_original);
   m_original_unique_pupu = make_unique_pupu(m_original_pupu);
@@ -383,7 +374,7 @@ void
 }
 
 void
-  ff_8::MapHistory::refresh_working_pupu() const
+  MapHistory::refresh_working_pupu() const
 {
   m_working_pupu        = calculate_pupu(m_working);
   m_working_unique_pupu = make_unique_pupu(m_working_pupu);
@@ -396,13 +387,13 @@ void
 }
 
 void
-  ff_8::MapHistory::refresh_original_conflicts() const
+  MapHistory::refresh_original_conflicts() const
 {
   m_original_conflicts = calculate_conflicts(m_original);
 }
 
 void
-  ff_8::MapHistory::refresh_working_conflicts() const
+  MapHistory::refresh_working_conflicts() const
 {
   m_working_conflicts      = calculate_conflicts(m_working);
   m_working_similar_counts = populate_similar_tile_count(
@@ -416,109 +407,109 @@ void
     m_working_animation_counts);
 }
 
-const std::vector<ff_8::PupuID> &
-  ff_8::MapHistory::original_pupu() const noexcept
+const std::vector<PupuID> &
+  MapHistory::original_pupu() const noexcept
 {
   return m_original_pupu;
 }
 
-const std::vector<ff_8::PupuID> &
-  ff_8::MapHistory::working_pupu() const noexcept
+const std::vector<PupuID> &
+  MapHistory::working_pupu() const noexcept
 {
   return m_working_pupu;
 }
 
-const std::vector<ff_8::PupuID> &
-  ff_8::MapHistory::original_unique_pupu() const noexcept
+const std::vector<PupuID> &
+  MapHistory::original_unique_pupu() const noexcept
 {
   return m_original_unique_pupu;
 }
 
-const std::vector<ff_8::PupuID> &
-  ff_8::MapHistory::working_unique_pupu() const noexcept
+const std::vector<PupuID> &
+  MapHistory::working_unique_pupu() const noexcept
 {
   return m_working_unique_pupu;
 }
 
-const std::vector<glm::vec4> &
-  ff_8::MapHistory::original_unique_pupu_color() const noexcept
+const std::vector<Color32RGBA> &
+  MapHistory::original_unique_pupu_color() const noexcept
 {
   return m_original_unique_pupu_color;
 }
 
-const std::vector<glm::vec4> &
-  ff_8::MapHistory::working_unique_pupu_color() const noexcept
+const std::vector<Color32RGBA> &
+  MapHistory::working_unique_pupu_color() const noexcept
 {
   return m_working_unique_pupu_color;
 }
 
-const ff_8::SourceTileConflicts &
-  ff_8::MapHistory::original_conflicts() const noexcept
+const SourceTileConflicts &
+  MapHistory::original_conflicts() const noexcept
 {
   return m_original_conflicts;
 }
 
-const ff_8::SourceTileConflicts &
-  ff_8::MapHistory::working_conflicts() const noexcept
+const SourceTileConflicts &
+  MapHistory::working_conflicts() const noexcept
 {
   return m_working_conflicts;
 }
 
-const ff_8::MapHistory::nst_map &
-  ff_8::MapHistory::working_similar_counts() const noexcept
+const MapHistory::nst_map &
+  MapHistory::working_similar_counts() const noexcept
 {
   return m_working_similar_counts;
 }
 
-const ff_8::MapHistory::nsat_map &
-  ff_8::MapHistory::working_animation_counts() const noexcept
+const MapHistory::nsat_map &
+  MapHistory::working_animation_counts() const noexcept
 {
   return m_working_animation_counts;
 }
 
 std::size_t
-  ff_8::MapHistory::count() const
+  MapHistory::count() const
 {
   return m_undo_history.size();
 }
 
 std::size_t
-  ff_8::MapHistory::redo_count() const
+  MapHistory::redo_count() const
 {
   return m_redo_history.size();
 }
 
 const map_t &
-  ff_8::MapHistory::original() const
+  MapHistory::original() const
 {
   return m_original;
 }
 
 map_t &
-  ff_8::MapHistory::original_mutable()
+  MapHistory::original_mutable()
 {
   return m_original;
 }
 
 map_t &
-  ff_8::MapHistory::working()
+  MapHistory::working()
 {
   return m_working;
 }
 
 const map_t &
-  ff_8::MapHistory::working() const
+  MapHistory::working() const
 {
   return m_working;
 }
 
 map_t &
-  ff_8::MapHistory::copy_original(std::string description)
+  MapHistory::copy_original(std::string description)
 {
   if (m_in_multi_frame_operation) {
     return original_mutable();
   }
-  (void)debug_count_print();
+  //(void)debug_count_print();
   clear_redo();
   m_undo_original_or_working.push_back(pushed::original);
   m_undo_history.push_back(original());
@@ -528,12 +519,12 @@ map_t &
 }
 
 map_t &
-  ff_8::MapHistory::copy_working(std::string description)
+  MapHistory::copy_working(std::string description)
 {
   if (m_in_multi_frame_operation) {
     return working();
   }
-  (void)debug_count_print();
+  //(void)debug_count_print();
   clear_redo();
   m_undo_original_or_working.push_back(pushed::working);
   m_undo_history.push_back(working());
@@ -543,19 +534,18 @@ map_t &
 }
 
 map_t &
-  ff_8::MapHistory::begin_multi_frame_working(std::string description)
+  MapHistory::begin_multi_frame_working(std::string description)
 {
   if (!m_in_multi_frame_operation) {
-    const auto pop_set = glengine::ScopeGuard{ [this] {
-      m_in_multi_frame_operation = true;
-    } };
-    return copy_working(std::move(description));
+    auto &result               = copy_working(std::move(description));
+    m_in_multi_frame_operation = true;
+    return result;
   }
   return working();
 }
 
 void
-  ff_8::MapHistory::end_multi_frame_working(std::string description)
+  MapHistory::end_multi_frame_working(std::string description)
 {
   m_in_multi_frame_operation = false;
   if (!description.empty() && !m_undo_change_descriptions.empty()) {
@@ -567,14 +557,14 @@ void
 }
 
 void
-  ff_8::MapHistory::clear_redo()
+  MapHistory::clear_redo()
 {
   m_redo_history.clear();
   m_redo_original_or_working.clear();
 }
 
 bool
-  ff_8::MapHistory::remove_duplicate()
+  MapHistory::remove_duplicate()
 {
   bool ret = false;
   while (undo_enabled() &&
@@ -590,9 +580,9 @@ bool
 }
 
 const map_t &
-  ff_8::MapHistory::first_to_original(std::string description)
+  MapHistory::first_to_original(std::string description)
 {
-  (void)debug_count_print();
+  //(void)debug_count_print();
   clear_redo();
   m_undo_history.push_back(original());
   m_undo_original_or_working.push_back(pushed::original);
@@ -603,9 +593,9 @@ const map_t &
 }
 
 const map_t &
-  ff_8::MapHistory::first_to_working(std::string description)
+  MapHistory::first_to_working(std::string description)
 {
-  (void)debug_count_print();
+  //(void)debug_count_print();
   clear_redo();
   m_undo_history.push_back(working());
   m_undo_original_or_working.push_back(pushed::working);
@@ -616,9 +606,9 @@ const map_t &
 }
 
 const map_t &
-  ff_8::MapHistory::copy_working_to_original(std::string description)
+  MapHistory::copy_working_to_original(std::string description)
 {
-  (void)debug_count_print();
+  //(void)debug_count_print();
   clear_redo();
   m_undo_history.push_back(original());
   m_undo_original_or_working.push_back(pushed::original);
@@ -630,9 +620,9 @@ const map_t &
 }
 
 bool
-  ff_8::MapHistory::redo()
+  MapHistory::redo()
 {
-  const auto count = debug_count_print();
+  // const auto count = debug_count_print();
   if (!redo_enabled()) {
     return false;
   }
@@ -658,9 +648,9 @@ bool
 }
 
 bool
-  ff_8::MapHistory::undo(bool skip_redo)
+  MapHistory::undo(bool skip_redo)
 {
-  const auto count = debug_count_print();
+  // const auto count = debug_count_print();
   if (!undo_enabled()) {
     return false;
   }
@@ -690,54 +680,54 @@ bool
   return true;
 }
 void
-  ff_8::MapHistory::undo_all()
+  MapHistory::undo_all()
 {
   while (undo()) {}
 }
 void
-  ff_8::MapHistory::redo_all()
+  MapHistory::redo_all()
 {
   while (redo()) {}
 }
 bool
-  ff_8::MapHistory::redo_enabled() const
+  MapHistory::redo_enabled() const
 {
   return !std::ranges::empty(m_redo_history)
       && !std::ranges::empty(m_redo_original_or_working);
 }
 
 bool
-  ff_8::MapHistory::undo_enabled() const
+  MapHistory::undo_enabled() const
 {
   return !std::ranges::empty(m_undo_history)
       && !std::ranges::empty(m_undo_original_or_working);
 }
 
 const map_t &
-  ff_8::MapHistory::const_working() const
+  MapHistory::const_working() const
 {
   return m_working;
 }
 
 template<is_tile TileT>
-[[nodiscard]] ff_8::PupuID
-  ff_8::MapHistory::get_pupu_from_working(const TileT &tile) const
+[[nodiscard]] PupuID
+  MapHistory::get_pupu_from_working(const TileT &tile) const
 {
   return m_original_pupu[static_cast<std::size_t>(
     get_offset_from_working(tile))];
 }
 
 // Explicit instantiation for Tiles
-template ff_8::PupuID
-  ff_8::MapHistory::get_pupu_from_working(const Tile1 &) const;
-template ff_8::PupuID
-  ff_8::MapHistory::get_pupu_from_working(const Tile2 &) const;
-template ff_8::PupuID
-  ff_8::MapHistory::get_pupu_from_working(const Tile3 &) const;
+template PupuID
+  MapHistory::get_pupu_from_working(const Tile1 &) const;
+template PupuID
+  MapHistory::get_pupu_from_working(const Tile2 &) const;
+template PupuID
+  MapHistory::get_pupu_from_working(const Tile3 &) const;
 
 template<open_viii::graphics::background::is_tile TileT>
 std::vector<TileT>::difference_type
-  ff_8::MapHistory::get_offset_from_working(const TileT &tile) const
+  MapHistory::get_offset_from_working(const TileT &tile) const
 {
   return working().visit_tiles(
     [&](const auto &tiles) -> std::vector<TileT>::difference_type {
@@ -755,14 +745,14 @@ std::vector<TileT>::difference_type
 }
 
 template std::vector<Tile1>::difference_type
-  ff_8::MapHistory::get_offset_from_working(const Tile1 &) const;
+  MapHistory::get_offset_from_working(const Tile1 &) const;
 template std::vector<Tile2>::difference_type
-  ff_8::MapHistory::get_offset_from_working(const Tile2 &) const;
+  MapHistory::get_offset_from_working(const Tile2 &) const;
 template std::vector<Tile3>::difference_type
-  ff_8::MapHistory::get_offset_from_working(const Tile3 &) const;
+  MapHistory::get_offset_from_working(const Tile3 &) const;
 
 std::string_view
-  ff_8::MapHistory::current_undo_description() const
+  MapHistory::current_undo_description() const
 {
   if (std::ranges::empty(m_undo_change_descriptions)) {
     return {};
@@ -771,7 +761,7 @@ std::string_view
 }
 
 std::string_view
-  ff_8::MapHistory::current_redo_description() const
+  MapHistory::current_redo_description() const
 {
   if (std::ranges::empty(m_redo_change_descriptions)) {
     return {};
@@ -779,8 +769,8 @@ std::string_view
   return m_redo_change_descriptions.back();
 }
 
-[[nodiscard]] ff_8::MapHistory::pushed
-  ff_8::MapHistory::current_undo_pushed() const
+[[nodiscard]] MapHistory::pushed
+  MapHistory::current_undo_pushed() const
 {
   if (std::ranges::empty(m_undo_original_or_working)) {
     return {};
@@ -788,11 +778,12 @@ std::string_view
   return m_undo_original_or_working.back();
 }
 
-[[nodiscard]] ff_8::MapHistory::pushed
-  ff_8::MapHistory::current_redo_pushed() const
+[[nodiscard]] MapHistory::pushed
+  MapHistory::current_redo_pushed() const
 {
   if (std::ranges::empty(m_redo_original_or_working)) {
     return {};
   }
   return m_redo_original_or_working.back();
 }
+}// namespace open_viii::graphics::background

--- a/src/open_viii/graphics/background/MapHistory.hpp
+++ b/src/open_viii/graphics/background/MapHistory.hpp
@@ -14,16 +14,12 @@
 #include <spdlog/spdlog.h>
 // #include <glengine/ScopeGuard.hpp>
 // #include <glm/glm.hpp>
-/**
- * @namespace ff_8
- * @brief Contains classes and utilities specific to the Final Fantasy VIII
- * field map editor.
- */
-namespace ff_8 {
+namespace open_viii::graphics::background {
+
 /**
  * @class MapHistory
- * @brief Tracks and manages the history of changes to original and working map
- * states.
+ * @brief Tracks and manages the history of changes to original and working
+ * map states.
  *
  * This class provides functionality to manage undo and redo operations,
  * track changes, and associate descriptions with each modification to the map
@@ -52,7 +48,7 @@ public:
   using nst_map = std::
     map<open_viii::graphics::background::NormalizedSourceTile, std::uint8_t>;
   using nsat_map = std::map<
-    open_viii::graphics::background::normalized_source_animated_tile,
+    open_viii::graphics::background::NormalizedSourceAnimatedTile,
     std::uint8_t>;
 
 private:
@@ -64,7 +60,7 @@ private:
    * until `end_multi_frame_working` is called, which sets it back to
    * `false`.
    */
-  mutable bool                   m_in_multi_frame_operation   = { false };
+  mutable bool                     m_in_multi_frame_operation   = { false };
   /**
    * @brief Indicates whether the original state has been changed.
    *
@@ -77,7 +73,7 @@ private:
    * @note This flag is used to track modifications to the original tile
    * data.
    */
-  mutable bool                   m_original_changed           = { false };
+  mutable bool                     m_original_changed           = { false };
 
   /**
    * @brief Indicates whether the working state has been changed.
@@ -90,61 +86,61 @@ private:
    *
    * @note This flag is used to track modifications to the working tile data.
    */
-  mutable bool                   m_working_changed            = { false };
+  mutable bool                     m_working_changed            = { false };
 
   // Current states
   /**
    * @brief The active original map state.
    */
-  map_t                          m_original                   = {};
+  map_t                            m_original                   = {};
 
   /**
    * @brief The active working map state.
    */
-  map_t                          m_working                    = {};
+  map_t                            m_working                    = {};
 
   // Corresponding PupuIDs
   /**
    * @brief PupuID list corresponding to the original map state.
    */
-  mutable std::vector<PupuID>    m_original_pupu              = {};
+  mutable std::vector<PupuID>      m_original_pupu              = {};
 
   /**
    * @brief PupuID list corresponding to the working map state.
    */
-  mutable std::vector<PupuID>    m_working_pupu               = {};
+  mutable std::vector<PupuID>      m_working_pupu               = {};
 
   // Corresponding PupuIDs
   /**
    * @brief Unique PupuID list corresponding to the original map state.
    */
-  mutable std::vector<PupuID>    m_original_unique_pupu       = {};
+  mutable std::vector<PupuID>      m_original_unique_pupu       = {};
 
   /**
    * @brief Unique PupuID list corresponding to the working map state.
    */
-  mutable std::vector<PupuID>    m_working_unique_pupu        = {};
+  mutable std::vector<PupuID>      m_working_unique_pupu        = {};
 
   /**
    * @brief Unique PupuID color list corresponding to the original map state.
    */
-  mutable std::vector<glm::vec4> m_original_unique_pupu_color = {};
+  mutable std::vector<Color32RGBA> m_original_unique_pupu_color = {};
 
   /**
    * @brief Unique PupuID color list corresponding to the working map state.
    */
-  mutable std::vector<glm::vec4> m_working_unique_pupu_color  = {};
+  mutable std::vector<Color32RGBA> m_working_unique_pupu_color  = {};
 
   // Corresponding Source Conflicts
   /**
    * @brief Source Conflict list corresponding to the original map state.
    */
-  mutable SourceTileConflicts    m_original_conflicts         = {};
+  mutable SourceTileConflicts      m_original_conflicts         = {};
 
   /**
    * @brief Source Conflict list corresponding to the working map state.
    */
-  mutable SourceTileConflicts    m_working_conflicts          = {};
+  mutable SourceTileConflicts      m_working_conflicts          = {};
 
   /**
    * @brief Made from Source Conflict list corresponding to the working map
@@ -153,65 +149,65 @@ private:
    * one location. Mostly just to high light it differently. Or provide a
    * user with information.
    */
-  mutable nst_map                m_working_similar_counts     = {};
+  mutable nst_map                  m_working_similar_counts     = {};
 
-  mutable nsat_map               m_working_animation_counts   = {};
+  mutable nsat_map                 m_working_animation_counts   = {};
 
   // Consolidated history and tracking
   /**
    * @brief Unified undo history for both original and working states.
    */
-  std::vector<map_t>             m_undo_history               = {};
+  std::vector<map_t>               m_undo_history               = {};
   /**
    * @brief Tracks whether a history entry belongs to the original or working
    * state.
    */
-  std::vector<pushed>            m_undo_original_or_working   = {};
+  std::vector<pushed>              m_undo_original_or_working   = {};
 
   // Redo history and tracking
   /**
    * @brief Unified redo history for both original and working states.
    */
-  std::vector<map_t>             m_redo_history               = {};
+  std::vector<map_t>               m_redo_history               = {};
 
   /**
    * @brief Tracks redo states for original or working states.
    */
-  std::vector<pushed>            m_redo_original_or_working   = {};
+  std::vector<pushed>              m_redo_original_or_working   = {};
 
   // New vectors for tracking descriptions of changes
   /**
    * @brief Descriptions of undo changes corresponding to
    * `m_undo_original_or_working`.
    */
-  std::vector<std::string>       m_undo_change_descriptions   = {};
+  std::vector<std::string>         m_undo_change_descriptions   = {};
 
   /**
    * @brief Descriptions of redo changes corresponding to
    * `m_redo_original_or_working`.
    */
-  std::vector<std::string>       m_redo_change_descriptions   = {};
+  std::vector<std::string>         m_redo_change_descriptions   = {};
 
-  /**
-   * @brief Debug utility to print the current map history count.
-   *
-   * Outputs the count of maps in history along with the file name and line
-   * number for debugging purposes.
-   *
-   * @return A `glengine::ScopeGuard` object that automatically logs debug
-   * information when it goes out of scope.
-   */
-  auto
-    debug_count_print() const
-  {
-    return glengine::ScopeGuard([&]() {
-      spdlog::debug(
-        "Map History Count: {}\n\t{}:{}",
-        count() + 2U,
-        __FILE__,
-        __LINE__);
-    });
-  }
+  // /**
+  //  * @brief Debug utility to print the current map history count.
+  //  *
+  //  * Outputs the count of maps in history along with the file name and line
+  //  * number for debugging purposes.
+  //  *
+  //  * @return A `glengine::ScopeGuard` object that automatically logs debug
+  //  * information when it goes out of scope.
+  //  */
+  // auto
+  //   debug_count_print() const
+  // {
+  //   return glengine::ScopeGuard([&]() {
+  //     spdlog::debug(
+  //       "Map History Count: {}\n\t{}:{}",
+  //       count() + 2U,
+  //       __FILE__,
+  //       __LINE__);
+  //   });
+  // }
 
   /**
    * @brief Retrieve and process a tile from the original map at a specific
@@ -644,7 +640,7 @@ public:
    * the original state.
    * @note The returned vector is guaranteed to contain only unique values.
    */
-  const std::vector<ff_8::PupuID> &
+  const std::vector<PupuID> &
     original_unique_pupu() const noexcept;
 
   /**
@@ -660,13 +656,13 @@ public:
    * the working state.
    * @note The returned vector is guaranteed to contain only unique values.
    */
-  const std::vector<ff_8::PupuID> &
+  const std::vector<PupuID> &
     working_unique_pupu() const noexcept;
 
   /**
    * @brief Retrieves the unique colors associated with the original PupuIDs.
    *
-   * This function provides a constant reference to a vector of `glm::vec4`
+   * This function provides a constant reference to a vector of `Color32RGBA`
    * color values corresponding to the unique PupuIDs from the original state
    * of the map.
    *
@@ -676,19 +672,19 @@ public:
    * targets. The colors are also cached in memory to allow reverse lookup
    * from a color back to its associated PupuID.
    *
-   * @return A constant reference to a vector of `glm::vec4` values, one per
+   * @return A constant reference to a vector of `Color32RGBA` values, one per
    * unique original PupuID.
    * @note The returned colors are guaranteed to be unique for each PupuID.
    * @warning Assertions may be added in the future to validate the
    * uniqueness of the mapping.
    */
-  const std::vector<glm::vec4> &
+  const std::vector<Color32RGBA> &
     original_unique_pupu_color() const noexcept;
 
   /**
    * @brief Retrieves the unique colors associated with the working PupuIDs.
    *
-   * This function provides a constant reference to a vector of `glm::vec4`
+   * This function provides a constant reference to a vector of `Color32RGBA`
    * color values corresponding to the unique PupuIDs from the working state
    * of the map.
    *
@@ -698,19 +694,19 @@ public:
    * targets. The colors are also cached in memory to allow reverse lookup
    * from a color back to its associated PupuID.
    *
-   * @return A constant reference to a vector of `glm::vec4` values, one per
+   * @return A constant reference to a vector of `Color32RGBA` values, one per
    * unique working PupuID.
    * @note The returned colors are guaranteed to be unique for each PupuID.
    * @warning Assertions may be added in the future to validate the
    * uniqueness of the mapping.
    */
-  const std::vector<glm::vec4> &
+  const std::vector<Color32RGBA> &
     working_unique_pupu_color() const noexcept;
 
   /**
    * @brief Retrieves the PupuID associated with a given working color.
    *
-   * This function performs a reverse lookup from a `glm::vec4` color value
+   * This function performs a reverse lookup from a `Color32RGBA` color value
    * to its corresponding `PupuID` in the working map state.
    *
    * Colors are generated uniquely for each `PupuID` to support rendering
@@ -730,7 +726,7 @@ public:
    *          the lookup will fail.
    */
   std::optional<PupuID>
-    working_color_to_pupu_id(const glm::vec4 &in_color) const noexcept
+    working_color_to_pupu_id(const Color32RGBA &in_color) const noexcept
   {
     auto color_and_ids
       = std::views::zip(working_unique_pupu_color(), working_unique_pupu());
@@ -1008,10 +1004,11 @@ public:
       m_redo_change_descriptions);
   }
 };
-}// namespace ff_8
+
+}// namespace open_viii::graphics::background
 
 template<>
-struct fmt::formatter<ff_8::MapHistory::pushed>
+struct fmt::formatter<open_viii::graphics::background::MapHistory::pushed>
   : fmt::formatter<std::string_view>
 {
   // tile_sizes::default_size, tile_sizes::x_2_size, tile_sizes::x_4_size,
@@ -1019,19 +1016,21 @@ struct fmt::formatter<ff_8::MapHistory::pushed>
   //  parse is inherited from formatter<string_view>.
   template<typename FormatContext>
   constexpr auto
-    format(ff_8::MapHistory::pushed pushed, FormatContext &ctx) const
+    format(
+      open_viii::graphics::background::MapHistory::pushed pushed,
+      FormatContext                                      &ctx) const
   {
     using namespace open_viii::graphics::background;
     using namespace std::string_view_literals;
     std::string_view name = {};
     switch (pushed) {
-    case ff_8::MapHistory::pushed::unknown:
+    case MapHistory::pushed::unknown:
       name = "Unknown"sv;
       break;
-    case ff_8::MapHistory::pushed::original:
+    case MapHistory::pushed::original:
       name = "Original"sv;
       break;
-    case ff_8::MapHistory::pushed::working:
+    case MapHistory::pushed::working:
       name = "Working"sv;
       break;
     }

--- a/src/open_viii/graphics/background/MapHistory.hpp
+++ b/src/open_viii/graphics/background/MapHistory.hpp
@@ -1,0 +1,1041 @@
+//
+// Created by pcvii on 6/2/2022.
+//
+
+#ifndef FIELD_MAP_EDITOR_MAPHISTORY_HPP
+#define FIELD_MAP_EDITOR_MAPHISTORY_HPP
+#include "Map.hpp"
+#include "NormalizedSourceTile.hpp"
+#include "PupuID.hpp"
+#include "SourceTileConflicts.hpp"
+#include "UniquifyPupu.hpp"
+#include <map>
+#include <ranges>
+#include <spdlog/spdlog.h>
+// #include <glengine/ScopeGuard.hpp>
+// #include <glm/glm.hpp>
+/**
+ * @namespace ff_8
+ * @brief Contains classes and utilities specific to the Final Fantasy VIII
+ * field map editor.
+ */
+namespace ff_8 {
+/**
+ * @class MapHistory
+ * @brief Tracks and manages the history of changes to original and working map
+ * states.
+ *
+ * This class provides functionality to manage undo and redo operations,
+ * track changes, and associate descriptions with each modification to the map
+ * states.
+ */
+class [[nodiscard]] MapHistory
+{
+public:
+  /**
+   * @enum pushed
+   * @brief Specifies whether a map state belongs to the original or working
+   * state.
+   */
+  enum class pushed : std::uint8_t
+  {
+    unknown,
+    original,
+    working
+  };
+
+  /**
+   * @typedef map_t
+   * @brief Alias for the `Map` type from `open_viii::graphics::background`.
+   */
+  using map_t   = open_viii::graphics::background::Map;
+  using nst_map = std::
+    map<open_viii::graphics::background::NormalizedSourceTile, std::uint8_t>;
+  using nsat_map = std::map<
+    open_viii::graphics::background::normalized_source_animated_tile,
+    std::uint8_t>;
+
+private:
+  /**
+   * @brief Indicates whether a multi-frame operation is in progress.
+   *
+   * This flag is set to `true` when `begin_multi_frame_working` is called
+   * and prevents additional copies of the working map from being created
+   * until `end_multi_frame_working` is called, which sets it back to
+   * `false`.
+   */
+  mutable bool                   m_in_multi_frame_operation   = { false };
+  /**
+   * @brief Indicates whether the original state has been changed.
+   *
+   * This boolean flag tracks whether changes have been made to the original
+   * tile data. It is set to `true` before changes are made to the original
+   * state, and may be set to `false` after changes are committed. However,
+   * changes may still be in progress when it is set to `false`, so it is
+   * important to check the state before performing any further operations.
+   *
+   * @note This flag is used to track modifications to the original tile
+   * data.
+   */
+  mutable bool                   m_original_changed           = { false };
+
+  /**
+   * @brief Indicates whether the working state has been changed.
+   *
+   * This boolean flag tracks whether changes have been made to the working
+   * tile data. It is set to `true` before making changes to the working
+   * state, and may be set to `false` after changes are completed. As with
+   * the original flag, the state may be in the middle of a change when it is
+   * set to `false`.
+   *
+   * @note This flag is used to track modifications to the working tile data.
+   */
+  mutable bool                   m_working_changed            = { false };
+
+  // Current states
+  /**
+   * @brief The active original map state.
+   */
+  map_t                          m_original                   = {};
+
+  /**
+   * @brief The active working map state.
+   */
+  map_t                          m_working                    = {};
+
+  // Corresponding PupuIDs
+  /**
+   * @brief PupuID list corresponding to the original map state.
+   */
+  mutable std::vector<PupuID>    m_original_pupu              = {};
+
+  /**
+   * @brief PupuID list corresponding to the working map state.
+   */
+  mutable std::vector<PupuID>    m_working_pupu               = {};
+
+  // Corresponding PupuIDs
+  /**
+   * @brief Unique PupuID list corresponding to the original map state.
+   */
+  mutable std::vector<PupuID>    m_original_unique_pupu       = {};
+
+  /**
+   * @brief Unique PupuID list corresponding to the working map state.
+   */
+  mutable std::vector<PupuID>    m_working_unique_pupu        = {};
+
+  /**
+   * @brief Unique PupuID color list corresponding to the original map state.
+   */
+  mutable std::vector<glm::vec4> m_original_unique_pupu_color = {};
+
+  /**
+   * @brief Unique PupuID color list corresponding to the working map state.
+   */
+  mutable std::vector<glm::vec4> m_working_unique_pupu_color  = {};
+
+  // Corresponding Source Conflicts
+  /**
+   * @brief Source Conflict list corresponding to the original map state.
+   */
+  mutable SourceTileConflicts    m_original_conflicts         = {};
+
+  /**
+   * @brief Source Conflict list corresponding to the working map state.
+   */
+  mutable SourceTileConflicts    m_working_conflicts          = {};
+
+  /**
+   * @brief Made from Source Conflict list corresponding to the working map
+   * state. m_working_conflicts.  We normalize a tile and then see what the
+   * count is. We're using this to know if a tile is being used in more than
+   * one location. Mostly just to high light it differently. Or provide a
+   * user with information.
+   */
+  mutable nst_map                m_working_similar_counts     = {};
+
+  mutable nsat_map               m_working_animation_counts   = {};
+
+  // Consolidated history and tracking
+  /**
+   * @brief Unified undo history for both original and working states.
+   */
+  std::vector<map_t>             m_undo_history               = {};
+  /**
+   * @brief Tracks whether a history entry belongs to the original or working
+   * state.
+   */
+  std::vector<pushed>            m_undo_original_or_working   = {};
+
+  // Redo history and tracking
+  /**
+   * @brief Unified redo history for both original and working states.
+   */
+  std::vector<map_t>             m_redo_history               = {};
+
+  /**
+   * @brief Tracks redo states for original or working states.
+   */
+  std::vector<pushed>            m_redo_original_or_working   = {};
+
+  // New vectors for tracking descriptions of changes
+  /**
+   * @brief Descriptions of undo changes corresponding to
+   * `m_undo_original_or_working`.
+   */
+  std::vector<std::string>       m_undo_change_descriptions   = {};
+
+  /**
+   * @brief Descriptions of redo changes corresponding to
+   * `m_redo_original_or_working`.
+   */
+  std::vector<std::string>       m_redo_change_descriptions   = {};
+
+  /**
+   * @brief Debug utility to print the current map history count.
+   *
+   * Outputs the count of maps in history along with the file name and line
+   * number for debugging purposes.
+   *
+   * @return A `glengine::ScopeGuard` object that automatically logs debug
+   * information when it goes out of scope.
+   */
+  auto
+    debug_count_print() const
+  {
+    return glengine::ScopeGuard([&]() {
+      spdlog::debug(
+        "Map History Count: {}\n\t{}:{}",
+        count() + 2U,
+        __FILE__,
+        __LINE__);
+    });
+  }
+
+  /**
+   * @brief Retrieve and process a tile from the original map at a specific
+   * offset.
+   *
+   * Invokes a lambda function on a tile in the original map at the specified
+   * position. Throws an exception if the position is out of bounds.
+   *
+   * @tparam TileT The type of tile to retrieve.
+   * @tparam PosT The type of the position (integral type).
+   * @tparam LambdaT The type of the lambda function to process the tile.
+   * @param pos The position of the tile in the original map.
+   * @param lambda The lambda function to invoke on the tile.
+   * @return The result of invoking the lambda function on the tile.
+   * @throws std::exception If the position is out of bounds.
+   */
+  template<typename TileT, std::integral PosT, typename LambdaT>
+  [[nodiscard]] auto
+    original_get_tile_at_offset(const PosT pos, LambdaT &&lambda) const
+  {
+    return original().visit_tiles([&](auto &tiles) {
+      if constexpr (
+        std::is_same_v<
+          std::ranges::range_value_t<std::remove_cvref_t<decltype(tiles)>>,
+          TileT>) {
+        auto front_tile = tiles.cbegin();
+        if (
+          std::cmp_less(pos, 0)
+          || std::cmp_greater_equal(pos, std::ranges::size(tiles))) {
+          spdlog::error(
+            "{}:{} pos in original to be 0 < {} < {} ",
+            __FILE__,
+            __LINE__,
+            pos,
+            std::ranges::size(tiles));
+          throw std::exception();
+        }
+        std::ranges::advance(front_tile, pos);
+        return lambda(*front_tile);
+      }
+      else {
+        if constexpr (!requires(TileT tile_t) {
+                        { lambda(tile_t) } -> std::same_as<void>;
+                      }) {
+          return typename std::remove_cvref_t<
+            std::invoke_result_t<decltype(lambda), TileT>>{};
+        }
+      }
+    });
+  }
+
+  /**
+   * @brief Retrieve and process a tile from the working map at a specific
+   * offset.
+   *
+   * Invokes a lambda function on a tile in the working map at the specified
+   * position.
+   *
+   * @tparam TileT The type of tile to retrieve.
+   * @tparam PosT The type of the position (integral type).
+   * @tparam LambdaT The type of the lambda function to process the tile.
+   * @param pos The position of the tile in the working map.
+   * @param lambda The lambda function to invoke on the tile.
+   * @return The result of invoking the lambda function on the tile.
+   */
+  template<
+    open_viii::graphics::background::is_tile TileT,
+    std::integral                            PosT,
+    typename LambdaT>
+  [[nodiscard]] auto
+    working_get_tile_at_offset(const PosT pos, LambdaT &&lambda) const
+  {
+    return working().visit_tiles([&](auto &tiles) {
+      if constexpr (
+        std::is_same_v<
+          std::ranges::range_value_t<std::remove_cvref_t<decltype(tiles)>>,
+          TileT>) {
+        auto tile = tiles.begin();
+        std::ranges::advance(tile, pos);
+        return lambda(*tile);
+      }
+      else {
+        if constexpr (!requires(TileT tile_t) {
+                        { lambda(tile_t) } -> std::same_as<void>;
+                      }) {
+          TileT v{};
+          using t = std::remove_cvref_t<decltype(lambda(v))>;
+          return t{};
+        }
+      }
+    });
+  }
+
+  /**
+   * @brief Regenerates the PupuID data for the original map.
+   */
+  void
+    refresh_original_pupu() const;
+
+  /**
+   * @brief Regenerates the PupuID data for the working map.
+   */
+  void
+    refresh_working_pupu() const;
+
+  /**
+   * @brief Regenerates the Source Conflicts data for the original map.
+   */
+  void
+    refresh_original_conflicts() const;
+
+  /**
+   * @brief Regenerates the Source Conflicts data for the working map.
+   */
+  void
+    refresh_working_conflicts() const;
+
+public:
+  /**
+   * @brief Default constructor.
+   *
+   * Initializes an empty `MapHistory` instance with no original or working
+   * map states.
+   */
+  MapHistory() = default;
+
+  /**
+   * @brief Constructs a `MapHistory` instance with an initial map state.
+   *
+   * @param map The initial map state to set as both the original and working
+   * map states.
+   *
+   * This constructor sets the provided `map` as the starting state for both
+   * the original and working maps, initializing the undo/redo history
+   * accordingly.
+   */
+  explicit MapHistory(map_t map);
+
+  /**
+   * @brief Retrieves the current original map.
+   * @return A constant reference to the original map.
+   */
+  const map_t &
+    original() const;
+
+  /**
+   * @brief Retrieves the current original map.
+   * @return A constant reference to the original map.
+   */
+  map_t &
+    original_mutable();
+
+  /**
+   * @brief Retrieves the current working map as a constant reference.
+   * @return A constant reference to the working map.
+   */
+  const map_t &
+    const_working() const;
+
+  /**
+   * @brief Retrieves the current working map.
+   * @return A constant reference to the working map.
+   */
+  const map_t &
+    working() const;
+
+  /**
+   * @brief Provides a mutable reference to the working map for
+   * modifications.
+   * @return A mutable reference to the working map.
+   */
+  map_t &
+    working();
+
+  /**
+   * @brief Creates a copy of the current working map and logs the planned
+   * change.
+   *
+   * If a multi-frame operation is in progress (m_in_multi_frame_operation is
+   * true), this function returns a reference to the current working map
+   * without creating a new copy. Otherwise, it captures the current state of
+   * the working map for undo purposes and associates it with a description
+   * of the change being planned.
+   *
+   * @param description A string describing the planned change to the working
+   * map. This description is logged and stored for use in the undo history
+   * UI.
+   * @return A mutable reference to the working map (either the current one
+   * or a new copy).
+   */
+  map_t &
+    copy_working(std::string description);
+
+  /**
+   * @brief Creates a copy of the current original map and logs the planned
+   * change.
+   *
+   * If a multi-frame operation is in progress (m_in_multi_frame_operation is
+   * true), this function returns a reference to the current original map
+   * without creating a new copy. Otherwise, it captures the current state of
+   * the original map for undo purposes and associates it with a description
+   * of the change being planned. The original map is used as the source for
+   * reading image data.
+   *
+   * @param description A string describing the planned change to the
+   * original map. This description is logged and stored for use in the undo
+   * history UI.
+   * @return A mutable reference to the original map (either the current one
+   * or a new copy).
+   */
+  map_t &
+    copy_original(std::string description);
+
+  /**
+   * @brief Begins a multi-frame operation, creating a single copy of the
+   * working map.
+   *
+   * This function starts a multi-frame operation by creating a copy of the
+   * working map and setting a flag to prevent additional copies until
+   * `end_multi_frame_working` is called. The provided description is used
+   * for the undo history.
+   *
+   * @param description A string describing the upcoming multi-frame
+   * change.
+   * @return A mutable reference to the working map copy.
+   * @note Subsequent calls to `copy_working` during the multi-frame
+   * operation will return the same working map without creating new
+   * copies.
+   */
+  map_t &
+    begin_multi_frame_working(std::string description);
+
+  /**
+   * @brief Ends a multi-frame operation, allowing new copies to be created.
+   *
+   * This function ends the multi-frame operation, allowing new copies of the
+   * working map to be created in subsequent operations. If a description is
+   * provided, it updates the description of the current undo history entry.
+   *
+   * @param description An optional string to update the undo history
+   * description. If empty, the original description is retained.
+   */
+  void
+    end_multi_frame_working(std::string description = {});
+
+  /**
+   * @brief Pushes the current original map to the undo history and sets it
+   * as the new original state.
+   *
+   * This function records the current original map state in the undo
+   * history, associates it with a provided description, and clears the redo
+   * history. It updates the original map to the earliest state in the undo
+   * history and marks it as changed. The function is used to establish a new
+   * original state while preserving the ability to undo the operation.
+   *
+   * @param description A string describing the change for the undo history.
+   * @return A const reference to the original map state.
+   * @note The `debug_count_print` function is called for debugging purposes.
+   * @note The redo history is cleared as part of this operation.
+   * @pre The `m_undo_history`, `m_undo_original_or_working`, and
+   * `m_undo_change_descriptions` containers must be properly initialized.
+   * @post The original map is updated to the earliest undo history state,
+   * `m_original_changed` is set to true, and the redo history is cleared.
+   * @throws None (assumes container operations and `debug_count_print` do
+   * not throw).
+   */
+  const map_t &
+    first_to_original(std::string description);
+
+  /**
+   * @brief Pushes the current working map to the undo history and sets it as
+   * the new working state.
+   *
+   * This function records the current working map state in the undo history,
+   * associates it with a provided description, and clears the redo history.
+   * It updates the working map to the earliest state in the undo history and
+   * marks it as changed. The function is used to establish a new working
+   * state while preserving the ability to undo the operation.
+   *
+   * @param description A string describing the change for the undo history.
+   * @return A const reference to the current working map state.
+   * @note The `debug_count_print` function is called for debugging purposes.
+   * @note The redo history is cleared as part of this operation.
+   * @pre The `m_undo_history`, `m_undo_original_or_working`, and
+   * `m_undo_change_descriptions` containers must be properly initialized.
+   * @post The working map is updated to the earliest undo history state,
+   * `m_working_changed` is set to true, and the redo history is cleared.
+   * @throws None (assumes container operations and `debug_count_print` do
+   * not throw).
+   */
+  const map_t &
+    first_to_working(std::string description);
+
+  /**
+   * @brief Copies the current working map to the original map and logs the
+   * reason for the operation.
+   *
+   * This function is used to make changes in the working map permanent by
+   * copying its state to the original map. It is commonly used during save
+   * operations. Additionally, the provided description explains the reason
+   * for making the changes permanent.
+   *
+   * @param description A string describing the reason for making the changes
+   * permanent.
+   *
+   * @return A constant reference to the updated original map.
+   *
+   * @details
+   * - This function updates the original map to match the working map,
+   * effectively committing the changes.
+   * - After calling this function, other components (e.g., texture loaders)
+   * may need updates to reflect the new state of the map, as changes could
+   * affect rendering or other operations.
+   */
+  const map_t &
+    copy_working_to_original(std::string description);
+
+  /**
+   * @brief Checks whether undo operations are possible.
+   * @return True if undo is enabled, false otherwise.
+   */
+  bool
+    undo_enabled() const;
+
+  /**
+   * @brief Checks whether redo operations are possible.
+   * @return True if redo is enabled, false otherwise.
+   */
+  bool
+    redo_enabled() const;
+
+  /**
+   * @brief Performs all available redo operations.
+   */
+  void
+    redo_all();
+
+  /**
+   * @brief Performs all available undo operations.
+   */
+  void
+    undo_all();
+
+  /**
+   * @brief Performs a single redo operation.
+   * @return True if a redo was successfully performed, false otherwise.
+   */
+  bool
+    redo();
+
+  /**
+   * @brief Performs a single undo operation.
+   * @param skip_redo If true, skips saving the undone change for redo.
+   * @return True if an undo was successfully performed, false otherwise.
+   */
+  bool
+    undo(bool skip_redo = false);
+
+  /**
+   * @brief Removes duplicate entries from the undo history.
+   * @return True if duplicates were found and removed, false otherwise.
+   */
+  bool
+    remove_duplicate();
+
+  /**
+   * @brief Retrieves the total number of changes in the undo history.
+   * @return The size of the undo history.
+   */
+  size_t
+    count() const;
+
+  /**
+   * @brief Regenerates all PupuID data and Source Conflicts data for the
+   * maps in the original state.
+   *
+   * This function regenerates the entire set of PupuID data and source
+   * conflicts for the maps in their original, unmodified state. It can be
+   * called to refresh the data, either for the first time or after
+   * significant changes have been made.
+   *
+   * @param force If `true`, forces a regeneration even if the data is
+   * considered up-to-date. If `false` (default), the regeneration occurs
+   * only if necessary.
+   */
+  void
+    refresh_original_all(bool force = false) const;
+
+  /**
+   * @brief Regenerates all PupuID data and Source Conflicts data for the
+   * maps in the working state.
+   *
+   * This function regenerates the entire set of PupuID data and source
+   * conflicts for the maps in their working state, which reflects any
+   * changes or modifications made. It is useful for updating the working
+   * state data after changes have occurred.
+   *
+   * @param force If `true`, forces a regeneration even if the data is
+   * considered up-to-date. If `false` (default), the regeneration occurs
+   * only if necessary.
+   */
+  void
+    refresh_working_all(bool force = false) const;
+
+  /**
+   * @brief Retrieves the PupuIDs for the original map.
+   * @return A constant reference to the vector of PupuIDs for the original
+   * map.
+   */
+  [[nodiscard]] const std::vector<PupuID> &
+    original_pupu() const noexcept;
+
+  /**
+   * @brief Retrieves the PupuIDs for the working map.
+   * @return A constant reference to the vector of PupuIDs for the working
+   * map.
+   */
+  [[nodiscard]] const std::vector<PupuID> &
+    working_pupu() const noexcept;
+
+  /**
+   * @brief Retrieves the unique PupuIDs for the original state of the map.
+   *
+   * This function provides a constant reference to a vector of unique
+   * `PupuID` values for the tiles in their original, unmodified state. These
+   * IDs are used to prevent conflicts or overlapping tiles in the unswizzled
+   * or rendered output for the original map data.
+   *
+   * @return A constant reference to a vector of unique `PupuID` values for
+   * the original state.
+   * @note The returned vector is guaranteed to contain only unique values.
+   */
+  const std::vector<ff_8::PupuID> &
+    original_unique_pupu() const noexcept;
+
+  /**
+   * @brief Retrieves the unique PupuIDs for the working state of the map.
+   *
+   * This function provides a constant reference to a vector of unique
+   * `PupuID` values for the tiles in their working state. The working state
+   * reflects any modifications made to the tiles or their layout. These IDs
+   * are used to ensure consistency and prevent conflicts in the unswizzled
+   * or rendered output for the working map data.
+   *
+   * @return A constant reference to a vector of unique `PupuID` values for
+   * the working state.
+   * @note The returned vector is guaranteed to contain only unique values.
+   */
+  const std::vector<ff_8::PupuID> &
+    working_unique_pupu() const noexcept;
+
+  /**
+   * @brief Retrieves the unique colors associated with the original PupuIDs.
+   *
+   * This function provides a constant reference to a vector of `glm::vec4`
+   * color values corresponding to the unique PupuIDs from the original state
+   * of the map.
+   *
+   * These colors are generated for use when drawing to a color attachment
+   * (e.g., in a mask rendering pass). Each unique PupuID is mapped to a
+   * distinct color, ensuring that tiles can be reliably identified in render
+   * targets. The colors are also cached in memory to allow reverse lookup
+   * from a color back to its associated PupuID.
+   *
+   * @return A constant reference to a vector of `glm::vec4` values, one per
+   * unique original PupuID.
+   * @note The returned colors are guaranteed to be unique for each PupuID.
+   * @warning Assertions may be added in the future to validate the
+   * uniqueness of the mapping.
+   */
+  const std::vector<glm::vec4> &
+    original_unique_pupu_color() const noexcept;
+
+  /**
+   * @brief Retrieves the unique colors associated with the working PupuIDs.
+   *
+   * This function provides a constant reference to a vector of `glm::vec4`
+   * color values corresponding to the unique PupuIDs from the working state
+   * of the map.
+   *
+   * These colors are generated for use when drawing to a color attachment
+   * (e.g., in a mask rendering pass). Each unique PupuID is mapped to a
+   * distinct color, ensuring that tiles can be reliably identified in render
+   * targets. The colors are also cached in memory to allow reverse lookup
+   * from a color back to its associated PupuID.
+   *
+   * @return A constant reference to a vector of `glm::vec4` values, one per
+   * unique working PupuID.
+   * @note The returned colors are guaranteed to be unique for each PupuID.
+   * @warning Assertions may be added in the future to validate the
+   * uniqueness of the mapping.
+   */
+  const std::vector<glm::vec4> &
+    working_unique_pupu_color() const noexcept;
+
+  /**
+   * @brief Retrieves the PupuID associated with a given working color.
+   *
+   * This function performs a reverse lookup from a `glm::vec4` color value
+   * to its corresponding `PupuID` in the working map state.
+   *
+   * Colors are generated uniquely for each `PupuID` to support rendering
+   * to a color attachment (e.g., mask rendering). This method allows
+   * translating a color read from such a render target back into the logical
+   * tile identifier (`PupuID`) it represents.
+   *
+   * @param in_color The color value to look up.
+   * @return An `std::optional<PupuID>` containing the corresponding PupuID
+   *         if the color exists in the working map, or `std::nullopt` if
+   *         no match is found.
+   *
+   * @note The mapping between colors and PupuIDs is guaranteed to be
+   * one-to-one, assuming color generation succeeded without collisions.
+   * @warning Floating-point equality (`==`) is used for comparison. Ensure
+   * the input color matches exactly a generated working color; otherwise,
+   *          the lookup will fail.
+   */
+  std::optional<PupuID>
+    working_color_to_pupu_id(const glm::vec4 &in_color) const noexcept
+  {
+    auto color_and_ids
+      = std::views::zip(working_unique_pupu_color(), working_unique_pupu());
+    if (
+      auto &&it = std::ranges::find_if(
+        color_and_ids,
+        [&](const auto &current_pair) {
+          auto &&[color, _] = current_pair;
+          return in_color == color;
+        });
+      it != std::ranges::end(color_and_ids)) {
+      return std::get<1>(*it);
+    }
+    return std::nullopt;
+  }
+
+  /**
+   * @brief Retrieves the current (working) tile conflicts.
+   *
+   * This function returns a constant reference to the current
+   * `SourceTileConflicts` object, which holds the conflicts between tiles
+   * in their current (working) state. The working conflicts represent the
+   * tile data that is actively being used or modified.
+   *
+   * @return A constant reference to the current `SourceTileConflicts`
+   * object.
+   */
+  [[nodiscard]] const SourceTileConflicts &
+    working_conflicts() const noexcept;
+
+  /**
+   * @brief Returns a constant reference to the map holding the count of
+   * similar tiles.
+   *
+   * This getter provides access to the `m_working_similar_counts` map, which
+   * contains the frequency of normalized tiles in the working map state. The
+   * map is of type `std::map<NormalizedSourceTile, std::uint8_t>`, where
+   * the key represents a normalized tile and the value represents how many
+   * times it appears.
+   *
+   * The function is marked as `noexcept`, meaning it does not throw any
+   * exceptions, and is marked as `[[nodiscard]]` to indicate that the return
+   * value should not be ignored.
+   *
+   * @return A constant reference to the map containing the count of similar
+   * tiles.
+   */
+  [[nodiscard]] const nst_map &
+    working_similar_counts() const noexcept;
+
+  [[nodiscard]] const nsat_map &
+    working_animation_counts() const noexcept;
+
+  /**
+   * @brief Retrieves the original tile conflicts.
+   *
+   * This function returns a constant reference to the original
+   * `SourceTileConflicts` object, which holds the conflicts between tiles
+   * in their initial, unmodified state. The original conflicts are typically
+   * used to compare against the working conflicts or as a reference.
+   *
+   * @return A constant reference to the original `SourceTileConflicts`
+   * object.
+   */
+  [[nodiscard]] const SourceTileConflicts &
+    original_conflicts() const noexcept;
+
+  /**
+   * @brief Retrieves the total number of redo operations available.
+   * @return The size of the redo history.
+   */
+  size_t
+    redo_count() const;
+
+  /**
+   * @brief Clears all redo history.
+   */
+  void
+    clear_redo();
+
+  /**
+   * @brief Retrieves the PupuID corresponding to the given working tile.
+   * @tparam TileT Type of the tile.
+   * @param tile Reference to the working tile.
+   * @return The corresponding PupuID.
+   */
+  template<open_viii::graphics::background::is_tile TileT>
+  [[nodiscard]] PupuID
+    get_pupu_from_working(const TileT &tile) const;
+
+  /**
+   * @brief Calculates the offset of the given tile in the working map.
+   * @tparam TileT Type of the tile.
+   * @param tile Reference to the tile.
+   * @return The offset of the tile.
+   */
+  template<open_viii::graphics::background::is_tile TileT>
+  [[nodiscard]] std::vector<TileT>::difference_type
+    get_offset_from_working(const TileT &tile) const;
+
+  /**
+   * @brief Copies the working map and applies a lambda to retrieve a new
+   * tile.
+   * @tparam TileT Type of the tile.
+   * @tparam LambdaT Type of the lambda function.
+   * @param tile Reference to the working tile.
+   * @param description A string describing the planned change to the working
+   * map. This description is logged and stored for use in the undo history
+   * UI.
+   * @param lambda Lambda function to apply.
+   * @return The new tile after the operation.
+   */
+  template<open_viii::graphics::background::is_tile TileT, typename LambdaT>
+  auto
+    copy_working_and_get_new_tile(
+      const TileT &tile,
+      std::string  description,
+      LambdaT    &&lambda)
+  {
+    const auto pos = get_offset_from_working(tile);
+    (void)copy_working(std::move(description));
+    return working_get_tile_at_offset<TileT>(
+      pos,
+      std::forward<LambdaT>(lambda));
+  }
+
+  /**
+   * @brief Copies the working map and performs operations on specific tile
+   * indexes.
+   * @tparam TileT Type of the tile.
+   * @tparam LambdaT Type of the lambda function.
+   * @param indexes Vector of tile indexes.
+   * @param description A string describing the planned change to the working
+   * map. This description is logged and stored for use in the undo history
+   * UI.
+   * @param lambda Lambda function to apply.
+   */
+  template<open_viii::graphics::background::is_tile TileT, typename LambdaT>
+  void
+    copy_working_perform_operation(
+      const std::vector<std::intmax_t> &indexes,
+      std::string                       description,
+      LambdaT                         &&lambda)
+  {
+    (void)copy_working(std::move(description));
+    for (const auto i : indexes) {
+      working_get_tile_at_offset<TileT>(i, lambda);
+    }
+  }
+
+  /**
+   * @brief Copies the working map and performs operations on tiles filtered
+   * by a lambda.
+   * @tparam TileT Type of the tile.
+   * @tparam FilterLambdaT Type of the filter lambda.
+   * @tparam LambdaT Type of the operation lambda.
+   * @param description A string describing the planned change to the working
+   * map. This description is logged and stored for use in the undo history
+   * UI.
+   * @param filter Lambda function for filtering tiles.
+   * @param lambda Lambda function to apply to filtered tiles.
+   */
+  template<
+    open_viii::graphics::background::is_tile TileT,
+    typename FilterLambdaT,
+    typename LambdaT>
+    requires(std::is_invocable_r_v<bool, FilterLambdaT, const TileT &>)
+  void
+    copy_working_perform_operation(
+      std::string     description,
+      FilterLambdaT &&filter,
+      LambdaT       &&lambda)
+  {
+    (void)copy_working(std::move(description));
+    working().visit_tiles([&](auto &tiles) {
+      if constexpr (
+        std::is_same_v<
+          std::ranges::range_value_t<std::remove_cvref_t<decltype(tiles)>>,
+          TileT>) {
+        auto filtered_tiles = tiles | std::views::filter(filter);
+        for (auto &tile : filtered_tiles) {
+          lambda(tile);
+        }
+      }
+    });
+  }
+
+  /**
+   * @brief Retrieves the original version of a working tile using a lambda.
+   * @tparam TileT Type of the tile.
+   * @tparam LambdaT Type of the lambda function.
+   * @param tile Reference to the working tile.
+   * @param lambda Lambda function to apply.
+   * @return The corresponding original tile after the operation.
+   */
+  template<open_viii::graphics::background::is_tile TileT, typename LambdaT>
+  auto
+    get_original_version_of_working_tile(const TileT &tile, LambdaT &&lambda)
+      const
+  {
+    return original_get_tile_at_offset<TileT>(
+      get_offset_from_working(tile),
+      std::forward<LambdaT>(lambda));
+  }
+
+  /**
+   * @brief Retrieves the description of the most recent undoable change.
+   *
+   * This function provides a string view of the description for the last
+   * change stored in the undo history, if available.
+   *
+   * @return A string view representing the description of the most recent
+   * undoable change. If there are no undoable changes, an empty string view
+   * is returned.
+   */
+  [[nodiscard]] std::string_view
+    current_undo_description() const;
+
+  /**
+   * @brief Retrieves the description of the most recent redoable change.
+   *
+   * This function provides a string view of the description for the last
+   * change stored in the redo history, if available.
+   *
+   * @return A string view representing the description of the most recent
+   * redoable change. If there are no redoable changes, an empty string view
+   * is returned.
+   */
+  [[nodiscard]] std::string_view
+    current_redo_description() const;
+  /**
+   * @brief Retrieves the type of the most recent undoable change.
+   *
+   * This function indicates whether the last change in the undo history
+   * corresponds to the original or working map, if available.
+   *
+   * @return A `pushed` value representing the type of the most recent
+   * undoable change. If there are no undoable changes, it returns
+   * `pushed::unknown`.
+   */
+  [[nodiscard]] pushed
+    current_undo_pushed() const;
+
+  /**
+   * @brief Retrieves the type of the most recent redoable change.
+   *
+   * This function indicates whether the last change in the redo history
+   * corresponds to the original or working map, if available.
+   *
+   * @return A `pushed` value representing the type of the most recent
+   * redoable change. If there are no redoable changes, it returns
+   * `pushed::unknown`.
+   */
+  [[nodiscard]] pushed
+    current_redo_pushed() const;
+
+  [[nodiscard]] auto
+    undo_history() const
+  {
+    return std::ranges::views::zip(
+      std::ranges::views::iota(
+        std::size_t{},
+        std::ranges::size(m_undo_original_or_working)),
+      m_undo_original_or_working,
+      m_undo_change_descriptions);
+  }
+  [[nodiscard]] auto
+    redo_history() const
+  {
+    return std::ranges::views::zip(
+      std::ranges::views::iota(
+        std::size_t{},
+        std::ranges::size(m_redo_original_or_working)),
+      m_redo_original_or_working,
+      m_redo_change_descriptions);
+  }
+};
+}// namespace ff_8
+
+template<>
+struct fmt::formatter<ff_8::MapHistory::pushed>
+  : fmt::formatter<std::string_view>
+{
+  // tile_sizes::default_size, tile_sizes::x_2_size, tile_sizes::x_4_size,
+  // tile_sizes::x_8_size, tile_sizes::x_16_size
+  //  parse is inherited from formatter<string_view>.
+  template<typename FormatContext>
+  constexpr auto
+    format(ff_8::MapHistory::pushed pushed, FormatContext &ctx) const
+  {
+    using namespace open_viii::graphics::background;
+    using namespace std::string_view_literals;
+    std::string_view name = {};
+    switch (pushed) {
+    case ff_8::MapHistory::pushed::unknown:
+      name = "Unknown"sv;
+      break;
+    case ff_8::MapHistory::pushed::original:
+      name = "Original"sv;
+      break;
+    case ff_8::MapHistory::pushed::working:
+      name = "Working"sv;
+      break;
+    }
+    return fmt::formatter<std::string_view>::format(name, ctx);
+  }
+};
+#endif// FIELD_MAP_EDITOR_MAPHISTORY_HPP

--- a/src/open_viii/graphics/background/MapHistory.hpp
+++ b/src/open_viii/graphics/background/MapHistory.hpp
@@ -1037,4 +1037,12 @@ struct fmt::formatter<open_viii::graphics::background::MapHistory::pushed>
     return fmt::formatter<std::string_view>::format(name, ctx);
   }
 };
+
+inline std::ostream &
+  operator<<(
+    std::ostream                                             &os,
+    const open_viii::graphics::background::MapHistory::pushed pushed)
+{
+  return os << fmt::format("{}", pushed);
+}
 #endif// FIELD_MAP_EDITOR_MAPHISTORY_HPP

--- a/src/open_viii/graphics/background/PupuID.cpp
+++ b/src/open_viii/graphics/background/PupuID.cpp
@@ -1,18 +1,17 @@
 #include "PupuID.hpp"
-namespace open_viii::graphics::background
+[[nodiscard]] std::string
+  open_viii::graphics::background::PupuID::create_summary() const
 {
-[[nodiscard]] std::string PupuID::create_summary() const
-{
-     return fmt::format(
-       "Layer ID: {}\nBlend Mode: {}\nAnimation ID: {}\nAnimation State: "
-       "{}\nOffset: {}\nX not aligned: {}\nY not aligned: {}",
-       layer_id(),
-       blend_mode(),
-       animation_id(),
-       animation_state(),
-       offset(),
-       is_x_not_aligned_to_grid(),
-       is_y_not_aligned_to_grid());
+  return fmt::format(
+    "Layer ID: {}\nBlend Mode: {}\nAnimation ID: {}\nAnimation State: "
+    "{}\nOffset: {}\nX not aligned: {}\nY not aligned: {}",
+    layer_id(),
+    blend_mode(),
+    animation_id(),
+    animation_state(),
+    offset(),
+    is_x_not_aligned_to_grid(),
+    is_y_not_aligned_to_grid());
 }
 
 // You are using all 32 bits without overlap.
@@ -25,11 +24,9 @@ namespace open_viii::graphics::background
 // flags, respectively. Therefore, all 32 bits are used without any overlap or
 // waste of space.
 
-
 // template PupuID::PupuID(const Tile1 &, std::uint8_t);
 // template PupuID::PupuID(const Tile2 &, std::uint8_t);
 // template PupuID::PupuID(const Tile3 &, std::uint8_t);
-
 
 // PupuID = uint32_t(0U + (tile.layer_id() <<
 // 24U)+(static_cast<std::uint32_t>(tile.blend_mode()) << 20U) +
@@ -50,8 +47,6 @@ namespace open_viii::graphics::background
 // [](const Sprite& sprite) {return sprite.ID; }); std::sort(IDs.begin(),
 // IDs.end()); auto it = std::unique(IDs.begin(), IDs.end()); IDs.erase(it,
 // IDs.end());
-}// namespace ff_8
-
 
 // struct PupuIDComparator
 // {

--- a/src/open_viii/graphics/background/PupuID.hpp
+++ b/src/open_viii/graphics/background/PupuID.hpp
@@ -201,8 +201,10 @@ struct PupuID
       "same_animation_state_base mask mismatch");
     return (m_raw & mask) == (right.raw() & mask);
   }
+
   using Float3 = std::array<float, 3>;
   using Float4 = std::array<float, 4>;
+
   [[nodiscard]] static constexpr float
     fract(float v) noexcept
   {

--- a/src/open_viii/graphics/background/PupuID.hpp
+++ b/src/open_viii/graphics/background/PupuID.hpp
@@ -227,7 +227,8 @@ struct PupuID
     hsv2rgb(float h, float s, float v) noexcept
   {
     const auto f = [&](float n) {
-      const float k = fract(n + h * 6.0f);
+      const float k = fract(n + h);
+
       return v
            * mix(1.0f, clamp(std::abs(k * 6.0f - 3.0f) - 1.0f, 0.0f, 1.0f), s);
     };

--- a/src/open_viii/graphics/background/PupuID.hpp
+++ b/src/open_viii/graphics/background/PupuID.hpp
@@ -8,6 +8,7 @@
 #include <compare>
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
+#include <string>
 namespace open_viii::graphics::background {
 struct PupuID
 {
@@ -200,9 +201,56 @@ struct PupuID
       "same_animation_state_base mask mismatch");
     return (m_raw & mask) == (right.raw() & mask);
   }
+  using Float3 = std::array<float, 3>;
+  using Float4 = std::array<float, 4>;
+  [[nodiscard]] static constexpr float
+    fract(float v) noexcept
+  {
+    return v - std::floor(v);
+  }
 
+  [[nodiscard]] static constexpr float
+    clamp(float v, float lo, float hi) noexcept
+  {
+    return v < lo ? lo : (v > hi ? hi : v);
+  }
+
+  [[nodiscard]] static constexpr float
+    mix(float a, float b, float t) noexcept
+  {
+    return a + (b - a) * t;
+  }
+
+  [[nodiscard]] static constexpr Float3
+    hsv2rgb(float h, float s, float v) noexcept
+  {
+    const auto f = [&](float n) {
+      const float k = fract(n + h * 6.0f);
+      return v
+           * mix(1.0f, clamp(std::abs(k * 6.0f - 3.0f) - 1.0f, 0.0f, 1.0f), s);
+    };
+
+    return { f(0.0f), f(2.0f / 3.0f), f(1.0f / 3.0f) };
+  }
+  [[nodiscard]] static constexpr Color32RGBA
+    encode_uint_to_rgba(std::uint32_t value) noexcept
+  {
+    static constexpr float GOLDEN_RATIO = 0.61803398875f;
+
+    const float hue = fract(static_cast<float>(value) * GOLDEN_RATIO);
+
+    const auto  rgb = hsv2rgb(hue, 0.8f, 0.9f);
+
+    Color32RGBA out{ static_cast<std::uint8_t>(rgb[0] * 255.0f),
+                     static_cast<std::uint8_t>(rgb[1] * 255.0f),
+                     static_cast<std::uint8_t>(rgb[2] * 255.0f),
+                     std::uint8_t{ 255U } };
+
+    return out;
+  }
   constexpr auto
     operator<=>(const PupuID &) const noexcept = default;
+
   [[nodiscard]] std::string
     create_summary() const;
 
@@ -210,26 +258,28 @@ private:
   std::uint32_t m_raw{};
 };
 }// namespace open_viii::graphics::background
+
 template<>
-struct fmt::formatter<open_viii::graphics::background::PupuID> : fmt::formatter<std::string>
+struct fmt::formatter<open_viii::graphics::background::PupuID>
+  : fmt::formatter<std::string>
 {
   // Formats value using the parsed format specification stored in this
   // formatter and writes the output to ctx.out().
   auto
-    format(const open_viii::graphics::background::PupuID &value, format_context &ctx) const
-    -> format_context::iterator
+    format(
+      const open_viii::graphics::background::PupuID &value,
+      format_context &ctx) const -> format_context::iterator
   {
     return fmt::format_to(ctx.out(), "{:08X}", value.raw());
   }
 };
 
-namespace open_viii::graphics::background
-{
+namespace open_viii::graphics::background {
 inline std::ostream &
-operator<<(std::ostream &os, const PupuID &value)
+  operator<<(std::ostream &os, const PupuID &value)
 {
   return os << fmt::format("{}", value);
 }
-}
+}// namespace open_viii::graphics::background
 
 #endif// OPEN_VIII_GRAPHICS_BACKGROUND_PUPUID_HPP

--- a/src/open_viii/graphics/background/PupuID.hpp
+++ b/src/open_viii/graphics/background/PupuID.hpp
@@ -5,10 +5,14 @@
 #ifndef OPEN_VIII_GRAPHICS_BACKGROUND_PUPUID_HPP
 #define OPEN_VIII_GRAPHICS_BACKGROUND_PUPUID_HPP
 #include "Map.hpp"
+#include <algorithm>
+#include <cmath>
 #include <compare>
+#include <cstdlib>
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
 #include <string>
+#include <version>
 namespace open_viii::graphics::background {
 struct PupuID
 {
@@ -202,19 +206,19 @@ struct PupuID
     return (m_raw & mask) == (right.raw() & mask);
   }
 
+#if defined(__cpp_lib_constexpr_cmath) && __cpp_lib_constexpr_cmath >= 202306L
+#define OPENVIII_CONSTEXPR_CMATH constexpr
+#else
+#define OPENVIII_CONSTEXPR_CMATH
+#endif
+
   using Float3 = std::array<float, 3>;
   using Float4 = std::array<float, 4>;
 
-  [[nodiscard]] static constexpr float
+  [[nodiscard]] static OPENVIII_CONSTEXPR_CMATH float
     fract(float v) noexcept
   {
     return v - std::floor(v);
-  }
-
-  [[nodiscard]] static constexpr float
-    clamp(float v, float lo, float hi) noexcept
-  {
-    return v < lo ? lo : (v > hi ? hi : v);
   }
 
   [[nodiscard]] static constexpr float
@@ -223,19 +227,22 @@ struct PupuID
     return a + (b - a) * t;
   }
 
-  [[nodiscard]] static constexpr Float3
+  [[nodiscard]] static OPENVIII_CONSTEXPR_CMATH Float3
     hsv2rgb(float h, float s, float v) noexcept
   {
     const auto f = [&](float n) {
       const float k = fract(n + h);
 
       return v
-           * mix(1.0f, clamp(std::abs(k * 6.0f - 3.0f) - 1.0f, 0.0f, 1.0f), s);
+           * mix(
+               1.0f,
+               std::clamp(std::abs(k * 6.0f - 3.0f) - 1.0f, 0.0f, 1.0f),
+               s);
     };
 
     return { f(0.0f), f(2.0f / 3.0f), f(1.0f / 3.0f) };
   }
-  [[nodiscard]] static constexpr Color32RGBA
+  [[nodiscard]] static OPENVIII_CONSTEXPR_CMATH Color32RGBA
     encode_uint_to_rgba(std::uint32_t value) noexcept
   {
     static constexpr float GOLDEN_RATIO = 0.61803398875f;
@@ -251,6 +258,7 @@ struct PupuID
 
     return out;
   }
+#undef OPENVIII_CONSTEXPR_CMATH
   constexpr auto
     operator<=>(const PupuID &) const noexcept = default;
 

--- a/src/open_viii/graphics/background/SourceTileConflicts.hpp
+++ b/src/open_viii/graphics/background/SourceTileConflicts.hpp
@@ -16,7 +16,7 @@ namespace open_viii::graphics::background {
 /**
  * @brief A class for tracking and resolving conflicts between source tiles.
  *
- * The `source_tile_conflicts` class is used to manage and analyze conflicts
+ * The `SourceTileConflicts` class is used to manage and analyze conflicts
  * between tiles in a grid. It provides methods to:
  * - Track the number of tiles at each location.
  * - Identify locations with conflicts (multiple tiles in the same spot).
@@ -28,7 +28,7 @@ namespace open_viii::graphics::background {
  *
  * @note The class is marked `final` to prevent inheritance.
  */
-class [[nodiscard]] source_tile_conflicts final
+class [[nodiscard]] SourceTileConflicts final
 {
 public:
   /**
@@ -75,8 +75,8 @@ public:
    * (`X_SIZE`) and height (`Y_SIZE`).
    */
   static constexpr auto GRID_SIZE = X_SIZE * Y_SIZE;
-#ifdef UT_source_tile_conflicts_test
-  // Code specific to UT_source_tile_conflicts_test
+#ifdef UT_SourceTileConflicts_test
+  // Code specific to UT_SourceTileConflicts_test
 public:
 #else
   // Code for other cases
@@ -204,7 +204,8 @@ private:
   {
     location l;
     if constexpr (std::signed_integral<Index>) {
-      assert(std::cmp_greater_equal(index, 0) && " index must be greater than 0");
+      assert(
+        std::cmp_greater_equal(index, 0) && " index must be greater than 0");
     }
     assert(
       std::cmp_less(index, X_SIZE * Y_SIZE * T_SIZE)
@@ -381,17 +382,17 @@ public:
   }
 
   // /**
-  //  * @brief Compares two `source_tile_conflicts` objects for ordering and
+  //  * @brief Compares two `SourceTileConflicts` objects for ordering and
   //  equality.
   //  *
   //  * This operator provides default comparison behavior using the
   //  three-way comparison operator.
   //  *
-  //  * @param other The other `source_tile_conflicts` object to compare.
+  //  * @param other The other `SourceTileConflicts` object to compare.
   //  * @return A `std::strong_ordering` indicating the result of the
   //  comparison.
   //  */
-  // constexpr auto               operator<=>(const source_tile_conflicts &)
+  // constexpr auto               operator<=>(const SourceTileConflicts &)
   // const noexcept = default;
 
   /**

--- a/tests/ArchiveRange.cpp
+++ b/tests/ArchiveRange.cpp
@@ -11,7 +11,7 @@ int
   using namespace boost::ut::operators::terse;
   using namespace boost::ut;
   using namespace open_viii::archive;
-  [[maybe_unused]] suite tests = [] -> void {
+  [[maybe_unused]] suite<"ArchiveRange"> tests = [] -> void {
     open_viii::Paths::for_each_path(
       [](const std::filesystem::path &path) -> open_viii::Paths::Ops {
         static constexpr auto coo = open_viii::LangT::en;

--- a/tests/BackgroundTiles.cpp
+++ b/tests/BackgroundTiles.cpp
@@ -7,153 +7,150 @@
 int
   main()
 {
-  using v_tile = std::variant<
-    open_viii::graphics::background::Tile1,
-    open_viii::graphics::background::Tile2,
-    open_viii::graphics::background::Tile3>;
-  using t_tile = std::tuple<
-    open_viii::graphics::background::Tile1,
-    open_viii::graphics::background::Tile2,
-    open_viii::graphics::background::Tile3>;
-  static constexpr auto tile_test = [](v_tile tile_var) {
-    std::visit(
-      [](auto tile) {
-        using namespace boost::ut::literals;
-        using namespace boost::ut::operators::terse;
-        using namespace boost::ut::operators;
+  using namespace boost::ut::literals;
+  using namespace boost::ut::operators::terse;
+  using namespace boost::ut::operators;
+  using namespace boost::ut;
+  using namespace open_viii;
+  using namespace open_viii::graphics::background;
+  using namespace open_viii::graphics::literals;
+  [[maybe_unused]] suite<"BackgroundTiles"> tests = [] {
+    using v_tile                    = std::variant<Tile1, Tile2, Tile3>;
+    using t_tile                    = std::tuple<Tile1, Tile2, Tile3>;
+    static constexpr auto tile_test = [](v_tile tile_var) {
+      std::visit(
+        [](auto tile) {
+          "Test tile values"_test = [&tile] {
+            expect(eq(tile.source_x(), 0U));
+            expect(eq(tile.source_y(), 0U));
+            expect(eq(tile.x(), 0));
+            expect(eq(tile.y(), 0));
+            expect(eq(tile.z(), 0U));
+            expect(eq(tile.blend(), 0U));
+            expect(eq(
+              static_cast<std::uint16_t>(tile.blend_mode()),
+              static_cast<std::uint16_t>(
+                open_viii::graphics::background::BlendModeT::none)));
+            expect(eq(tile.draw(), false));
+            expect(eq(
+              static_cast<std::uint16_t>(tile.animation_id()),
+              static_cast<std::uint16_t>(0xFFU)));
+            expect(eq(tile.animation_state(), 0U));
+            expect(eq(tile.depth(), 4_bpp));
+            expect(eq(tile.texture_id(), 0U));
+            expect(eq(tile.layer_id(), 0U));
+            expect(eq(tile.palette_id(), 0U));
+          };
+          "Test Rectangles of tile"_test = [&tile] {
+            const auto src_rec = tile.source_rectangle();
+            expect(eq(src_rec.x(), 0U));
+            expect(eq(src_rec.y(), 0U));
+            expect(eq(src_rec.width(), 16U));
+            expect(eq(src_rec.height(), 16U));
+            const auto out_rec = tile.output_rectangle();
+            expect(eq(out_rec.x(), 0));
+            expect(eq(out_rec.y(), 0));
+            expect(eq(out_rec.width(), 16));
+            expect(eq(out_rec.height(), 16));
+          };
+          "Test modification of tile"_test = [&tile] {
+            tile = tile.with_source_x(1U)
+                     .with_source_y(2U)
+                     .with_x(3)
+                     .with_y(4)
+                     .with_z(5U)
+                     .with_texture_id(6U)
+                     .with_blend(1U)
+                     .with_depth(8_bpp)
+                     .with_draw(true)
+                     .with_palette_id(1U);
+            {
+              using T = decltype(tile);
+              using namespace open_viii::graphics::background;
+              if constexpr (has_with_layer_id<T>)
+                tile = tile.with_layer_id(1U);
+              if constexpr (has_with_blend_mode<T>)
+                tile = tile.with_blend_mode(
+                  open_viii::graphics::background::BlendModeT::quarter_add);
+              if constexpr (has_with_animation_id<T>)
+                tile = tile.with_animation_id(1U);
+              if constexpr (has_with_animation_state<T>)
+                tile = tile.with_animation_state(1U);
+            }
+            expect(eq(tile.source_x(), 1U));
+            expect(eq(tile.source_y(), 2U));
+            expect(eq(tile.x(), 3));
+            expect(eq(tile.y(), 4));
+            expect(eq(tile.z(), 5U));
+            expect(eq(tile.texture_id(), 6U));
+            expect(eq(static_cast<std::uint16_t>(tile.blend()), 1U));
+            expect(eq(tile.depth(), 8_bpp));
+            expect(eq(tile.draw(), true));
+            tile = tile.with_xy(5, 6);
+            expect(eq(tile.x(), 5));
+            expect(eq(tile.y(), 6));
+            tile = tile.with_source_xy(7U, 8U);
+            expect(eq(tile.source_x(), 7U));
+            expect(eq(tile.source_y(), 8U));
+            tile = tile.with_xy(decltype(tile.xy()){ 10, 11 });
+            expect(eq(tile.x(), 10));
+            expect(eq(tile.y(), 11));
+            tile = tile.with_source_xy(decltype(tile.source_xy()){ 15U, 16U });
+            expect(eq(tile.source_x(), 15U));
+            expect(eq(tile.source_y(), 16U));
+            // below may not change if it's const.
+            using namespace boost::ut::operators;
+            expect(
+              bool{ eq(static_cast<std::uint16_t>(tile.layer_id()), 1U) }
+              or bool{ eq(static_cast<std::uint16_t>(tile.layer_id()), 0U) });
+            expect(
+              bool{ eq(
+                static_cast<std::uint16_t>(tile.blend_mode()),
+                static_cast<std::uint16_t>(
+                  open_viii::graphics::background::BlendModeT::quarter_add)) }
+              or bool{ eq(
+                static_cast<std::uint16_t>(tile.blend_mode()),
+                static_cast<std::uint16_t>(
+                  open_viii::graphics::background::BlendModeT::none)) });
+            expect(
+              bool{ eq(static_cast<std::uint16_t>(tile.animation_id()), 1U) }
+              or bool{
+                eq(static_cast<std::uint16_t>(tile.animation_id()), 255U) });
+            expect(
+              bool{ eq(static_cast<std::uint16_t>(tile.animation_state()), 1U) }
+              or bool{
+                eq(static_cast<std::uint16_t>(tile.animation_state()), 0U) });
+          };
+        },
+        tile_var);
+      {
         using namespace boost::ut;
-        using namespace open_viii;
+        auto tile1 = open_viii::graphics::background::Tile1{};
+        memcpy(
+          &tile1,
+          "\x08\x00\x68\x00\x04\x00\x34\x00\x40\x3E\xD0\xC0\x00\x01\xFF\x00",
+          sizeof(tile1));
         using namespace open_viii::graphics::literals;
-        "Test tile values"_test = [&tile] {
-          expect(eq(tile.source_x(), 0U));
-          expect(eq(tile.source_y(), 0U));
-          expect(eq(tile.x(), 0));
-          expect(eq(tile.y(), 0));
-          expect(eq(tile.z(), 0U));
-          expect(eq(tile.blend(), 0U));
-          expect(eq(
-            static_cast<std::uint16_t>(tile.blend_mode()),
-            static_cast<std::uint16_t>(
-              open_viii::graphics::background::BlendModeT::none)));
-          expect(eq(tile.draw(), false));
-          expect(eq(
-            static_cast<std::uint16_t>(tile.animation_id()),
-            static_cast<std::uint16_t>(0xFFU)));
-          expect(eq(tile.animation_state(), 0U));
-          expect(eq(tile.depth(), 4_bpp));
-          expect(eq(tile.texture_id(), 0U));
-          expect(eq(tile.layer_id(), 0U));
-          expect(eq(tile.palette_id(), 0U));
-        };
-        "Test Rectangles of tile"_test = [&tile] {
-          const auto src_rec = tile.source_rectangle();
-          expect(eq(src_rec.x(), 0U));
-          expect(eq(src_rec.y(), 0U));
-          expect(eq(src_rec.width(), 16U));
-          expect(eq(src_rec.height(), 16U));
-          const auto out_rec = tile.output_rectangle();
-          expect(eq(out_rec.x(), 0));
-          expect(eq(out_rec.y(), 0));
-          expect(eq(out_rec.width(), 16));
-          expect(eq(out_rec.height(), 16));
-        };
-        "Test modification of tile"_test = [&tile] {
-          tile = tile.with_source_x(1U)
-                   .with_source_y(2U)
-                   .with_x(3)
-                   .with_y(4)
-                   .with_z(5U)
-                   .with_texture_id(6U)
-                   .with_blend(1U)
-                   .with_depth(8_bpp)
-                   .with_draw(true)
-                   .with_palette_id(1U);
-          {
-            using T = decltype(tile);
-            using namespace open_viii::graphics::background;
-            if constexpr (has_with_layer_id<T>)
-              tile = tile.with_layer_id(1U);
-            if constexpr (has_with_blend_mode<T>)
-              tile = tile.with_blend_mode(
-                open_viii::graphics::background::BlendModeT::quarter_add);
-            if constexpr (has_with_animation_id<T>)
-              tile = tile.with_animation_id(1U);
-            if constexpr (has_with_animation_state<T>)
-              tile = tile.with_animation_state(1U);
-          }
-          expect(eq(tile.source_x(), 1U));
-          expect(eq(tile.source_y(), 2U));
-          expect(eq(tile.x(), 3));
-          expect(eq(tile.y(), 4));
-          expect(eq(tile.z(), 5U));
-          expect(eq(tile.texture_id(), 6U));
-          expect(eq(static_cast<std::uint16_t>(tile.blend()), 1U));
-          expect(eq(tile.depth(), 8_bpp));
-          expect(eq(tile.draw(), true));
-          tile = tile.with_xy(5, 6);
-          expect(eq(tile.x(), 5));
-          expect(eq(tile.y(), 6));
-          tile = tile.with_source_xy(7U, 8U);
-          expect(eq(tile.source_x(), 7U));
-          expect(eq(tile.source_y(), 8U));
-          tile = tile.with_xy(decltype(tile.xy()){ 10, 11 });
-          expect(eq(tile.x(), 10));
-          expect(eq(tile.y(), 11));
-          tile = tile.with_source_xy(decltype(tile.source_xy()){ 15U, 16U });
-          expect(eq(tile.source_x(), 15U));
-          expect(eq(tile.source_y(), 16U));
-          // below may not change if it's const.
-          using namespace boost::ut::operators;
-          expect(
-            bool{ eq(static_cast<std::uint16_t>(tile.layer_id()), 1U) }
-            or bool{ eq(static_cast<std::uint16_t>(tile.layer_id()), 0U) });
-          expect(
-            bool{ eq(
-              static_cast<std::uint16_t>(tile.blend_mode()),
-              static_cast<std::uint16_t>(
-                open_viii::graphics::background::BlendModeT::quarter_add)) }
-            or bool{ eq(
-              static_cast<std::uint16_t>(tile.blend_mode()),
-              static_cast<std::uint16_t>(
-                open_viii::graphics::background::BlendModeT::none)) });
-          expect(
-            bool{ eq(static_cast<std::uint16_t>(tile.animation_id()), 1U) }
-            or bool{
-              eq(static_cast<std::uint16_t>(tile.animation_id()), 255U) });
-          expect(
-            bool{ eq(static_cast<std::uint16_t>(tile.animation_state()), 1U) }
-            or bool{
-              eq(static_cast<std::uint16_t>(tile.animation_state()), 0U) });
-        };
+        auto tile1_gamma
+          = tile1.with_source_xy({ 208, 192 })
+              .with_xy({ 8, 104 })
+              .with_z(4)
+              .with_depth(4_bpp)
+              .with_palette_id(9)
+              .with_texture_id(4)
+              .with_layer_id(0)
+              .with_blend_mode(open_viii::graphics::background::BlendModeT::add)
+              .with_blend(1)
+              .with_animation_id(255)
+              .with_animation_state(0)
+              .with_draw(1);
+        expect(eq(tile1, tile1_gamma));
+      }
+    };
+    std::apply(
+      [](auto... values) {
+        ((void)tile_test(values), ...);
       },
-      tile_var);
-    {
-      using namespace boost::ut;
-      auto tile1 = open_viii::graphics::background::Tile1{};
-      memcpy(
-        &tile1,
-        "\x08\x00\x68\x00\x04\x00\x34\x00\x40\x3E\xD0\xC0\x00\x01\xFF\x00",
-        sizeof(tile1));
-      using namespace open_viii::graphics::literals;
-      auto tile1_gamma
-        = tile1.with_source_xy({ 208, 192 })
-            .with_xy({ 8, 104 })
-            .with_z(4)
-            .with_depth(4_bpp)
-            .with_palette_id(9)
-            .with_texture_id(4)
-            .with_layer_id(0)
-            .with_blend_mode(open_viii::graphics::background::BlendModeT::add)
-            .with_blend(1)
-            .with_animation_id(255)
-            .with_animation_state(0)
-            .with_draw(1);
-      expect(eq(tile1, tile1_gamma));
-    }
+      t_tile{});
   };
-  std::apply(
-    [](auto... values) {
-      ((void)tile_test(values), ...);
-    },
-    t_tile{});
 }

--- a/tests/BattleStage.cpp
+++ b/tests/BattleStage.cpp
@@ -3,25 +3,24 @@
 #include <boost/ut.hpp>
 #include <cstdint>
 #include <iostream>
-void
-  test_clut_ids()
-{
-  static constexpr std::array<std::uint16_t, 16U> clutids = {
-    0x3C00U, 0x3C40U, 0x3C80U, 0x3CC0U, 0x3D00U, 0x3D40U, 0x3D80U, 0x3DC0U,
-    0x3E00U, 0x3E40U, 0x3E80U, 0x3EC0U, 0x3F00U, 0x3F40U, 0x3F80U, 0x3FC0U,
-  };
-  for (std::uint8_t i = 0; const auto &clutid : clutids) {
-    boost::ut::expect(
-      boost::ut::eq(
-        +static_cast<std::uint8_t>(open_viii::battle::stage::RawClut(clutid)),
-        i++));
-  }
-}
 int
   main()
 {
   using namespace boost::ut::literals;
-  "test_clut_ids"_test = []() {
-    test_clut_ids();
+  using namespace boost::ut::operators::terse;
+  using namespace boost::ut;
+  [[maybe_unused]] suite<"BattleStage"> tests = [] {
+    using namespace boost::ut::literals;
+    "test_clut_ids"_test = []() {
+      static constexpr std::array<std::uint16_t, 16U> clutids = {
+        0x3C00U, 0x3C40U, 0x3C80U, 0x3CC0U, 0x3D00U, 0x3D40U, 0x3D80U, 0x3DC0U,
+        0x3E00U, 0x3E40U, 0x3E80U, 0x3EC0U, 0x3F00U, 0x3F40U, 0x3F80U, 0x3FC0U,
+      };
+      for (std::uint8_t i = 0; const auto &clutid : clutids) {
+        expect(eq(
+          +static_cast<std::uint8_t>(open_viii::battle::stage::RawClut(clutid)),
+          i++));
+      }
+    };
   };
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,3 +59,8 @@ add_test_common(SourceTileConflicts)
 target_link_libraries(${PROJECT_NAME}_UT_SourceTileConflicts
         PRIVATE ${PROJECT_NAME}_VIIIGraphics
 )
+
+add_test_common(MapHistory)
+target_link_libraries(${PROJECT_NAME}_UT_MapHistory
+        PRIVATE ${PROJECT_NAME}_VIIIGraphics
+)

--- a/tests/FI.cpp
+++ b/tests/FI.cpp
@@ -9,7 +9,7 @@ int
   using namespace boost::ut;
   using namespace open_viii::archive;
   using namespace open_viii;
-  [[maybe_unused]] suite tests = [] {
+  [[maybe_unused]] suite<"FI"> tests = [] {
     static constexpr auto check_fi
       = [](
           const std::uint32_t               &size,

--- a/tests/FL.cpp
+++ b/tests/FL.cpp
@@ -13,7 +13,7 @@ int
   using namespace std::string_literals;
   using namespace std::string_view_literals;
   using namespace open_viii::archive;
-  [[maybe_unused]] suite tests = [] {
+  [[maybe_unused]] suite<"FL"> tests = [] {
     {
       static const auto check_path_strings = [](std::string &&input) {
         const auto find_r = [](const char &c) -> bool {

--- a/tests/FS.cpp
+++ b/tests/FS.cpp
@@ -80,244 +80,247 @@ int
   using namespace boost::ut;
   using namespace open_viii::archive;
   using namespace open_viii::compression;
-  static constexpr std::string_view test_string("HELLO WORLD! 0123456789");
-  static constexpr mock_span_data   mock0(test_string);
-  static constexpr mock_span_data   mock1(test_string, 0, 5);
-  static constexpr mock_span_data   mock2(test_string, 6, 6);
-  static constexpr mock_span_data   mock3(
-    test_string,
-    static_cast<std::uint32_t>(std::size(test_string) - 10));
-  const auto temp_file
-    = tl::utility::create_temp_file("FS_test_uncompressed.tmp", test_string);
-  static constexpr auto check_fs
-    = [](auto full_data, const mock_span_data &mock) {
-        const auto value = FS::get_entry(full_data, mock.fi());
-        expect(std::ranges::equal(value, mock.string_view()));
+  [[maybe_unused]] suite<"FS"> tests = [] {
+    static constexpr std::string_view test_string("HELLO WORLD! 0123456789");
+    static constexpr mock_span_data   mock0(test_string);
+    static constexpr mock_span_data   mock1(test_string, 0, 5);
+    static constexpr mock_span_data   mock2(test_string, 6, 6);
+    static constexpr mock_span_data   mock3(
+      test_string,
+      static_cast<std::uint32_t>(std::size(test_string) - 10));
+    const auto temp_file
+      = tl::utility::create_temp_file("FS_test_uncompressed.tmp", test_string);
+    static constexpr auto check_fs
+      = [](auto full_data, const mock_span_data &mock) {
+          const auto value = FS::get_entry(full_data, mock.fi());
+          expect(std::ranges::equal(value, mock.string_view()));
+        };
+    static constexpr auto check_fs2
+      = [](auto full_data, const mock_span_data &mock, const FI &fi) {
+          const auto value = [&]() {
+            if constexpr (can_be_span_of_char<decltype(full_data)>) {
+              return FS::get_entry(std::span<const char>(full_data), fi);
+            }
+            else {
+              return FS::get_entry(full_data, fi);
+            }
+          }();
+          expect(std::ranges::equal(value, mock.string_view()));
+        };
+    "read entire span"_test = [] {
+      check_fs(mock0.span(), mock0);
+      check_fs(mock0.span(), mock1);
+      check_fs(mock0.span(), mock2);
+      check_fs(mock0.span(), mock3);
+    };
+    "read entire file"_test = [&temp_file] {
+      expect(temp_file.has_value());
+      expect(std::filesystem::exists(temp_file.value()));
+      check_fs(temp_file.value(), mock0);
+      check_fs(temp_file.value(), mock1);
+      check_fs(temp_file.value(), mock2);
+      check_fs(temp_file.value(), mock3);
+    };
+    {
+      std::vector<FI> fi_buffer{};
+      fi_buffer.reserve(3);
+      std::vector<char> uncompressed_buffer{};
+      const auto        add_uncompressed_data
+        = [&uncompressed_buffer, &fi_buffer](const mock_span_data &mock) {
+            fi_buffer.push_back(
+              append_entry(uncompressed_buffer, mock.span(), mock.fi()));
+          };
+      add_uncompressed_data(mock1);
+      add_uncompressed_data(mock2);
+      add_uncompressed_data(mock3);
+      "read entire span"_test = [&uncompressed_buffer, &fi_buffer] {
+        check_fs2(uncompressed_buffer, mock1, fi_buffer[0]);
+        check_fs2(uncompressed_buffer, mock2, fi_buffer[1]);
+        check_fs2(uncompressed_buffer, mock3, fi_buffer[2]);
       };
-  static constexpr auto check_fs2
-    = [](auto full_data, const mock_span_data &mock, const FI &fi) {
-        const auto value = [&]() {
-          if constexpr (can_be_span_of_char<decltype(full_data)>) {
-            return FS::get_entry(std::span<const char>(full_data), fi);
-          }
-          else {
-            return FS::get_entry(full_data, fi);
-          }
-        }();
-        expect(std::ranges::equal(value, mock.string_view()));
+    }
+    {
+      // write compressed LZSS data to buffer
+      std::vector<FI> fi_buffer{};
+      fi_buffer.reserve(3);
+      std::vector<char> compressed_buffer{};
+      const auto        add_lzss_data
+        = [&compressed_buffer, &fi_buffer](const mock_span_data &mock) {
+            fi_buffer.push_back(append_entry(
+              compressed_buffer,
+              mock.span(),
+              open_viii::CompressionTypeT::lzss));
+          };
+      add_lzss_data(mock1);
+      add_lzss_data(mock2);
+      add_lzss_data(mock3);
+      const auto compressed_temp_file = tl::utility::create_temp_file(
+        "FS_test_Lzss.tmp",
+        std::string_view(
+          std::data(compressed_buffer),
+          std::size(compressed_buffer)));
+      "read entire span"_test = [&compressed_buffer, &fi_buffer] {
+        check_fs2(compressed_buffer, mock1, fi_buffer[0]);
+        check_fs2(compressed_buffer, mock2, fi_buffer[1]);
+        check_fs2(compressed_buffer, mock3, fi_buffer[2]);
       };
-  "read entire span"_test = [] {
-    check_fs(mock0.span(), mock0);
-    check_fs(mock0.span(), mock1);
-    check_fs(mock0.span(), mock2);
-    check_fs(mock0.span(), mock3);
-  };
-  "read entire file"_test = [&temp_file] {
-    expect(temp_file.has_value());
-    expect(std::filesystem::exists(temp_file.value()));
-    check_fs(temp_file.value(), mock0);
-    check_fs(temp_file.value(), mock1);
-    check_fs(temp_file.value(), mock2);
-    check_fs(temp_file.value(), mock3);
-  };
-  {
-    std::vector<FI> fi_buffer{};
-    fi_buffer.reserve(3);
-    std::vector<char> uncompressed_buffer{};
-    const auto        add_uncompressed_data
-      = [&uncompressed_buffer, &fi_buffer](const mock_span_data &mock) {
-          fi_buffer.push_back(
-            append_entry(uncompressed_buffer, mock.span(), mock.fi()));
-        };
-    add_uncompressed_data(mock1);
-    add_uncompressed_data(mock2);
-    add_uncompressed_data(mock3);
-    "read entire span"_test = [&uncompressed_buffer, &fi_buffer] {
-      check_fs2(uncompressed_buffer, mock1, fi_buffer[0]);
-      check_fs2(uncompressed_buffer, mock2, fi_buffer[1]);
-      check_fs2(uncompressed_buffer, mock3, fi_buffer[2]);
+      "read entire file"_test = [&compressed_temp_file, &fi_buffer] {
+        expect(compressed_temp_file.has_value());
+        expect(std::filesystem::exists(compressed_temp_file.value()));
+        check_fs2(compressed_temp_file.value(), mock1, fi_buffer[0]);
+        check_fs2(compressed_temp_file.value(), mock2, fi_buffer[1]);
+        check_fs2(compressed_temp_file.value(), mock3, fi_buffer[2]);
+      };
+    }
+    {
+      // write compressed L4Z data to buffer
+      std::vector<FI> fi_buffer{};
+      fi_buffer.reserve(3);
+      std::vector<char> compressed_buffer{};
+      const auto        add_l4z_data
+        = [&compressed_buffer, &fi_buffer](const mock_span_data &mock) {
+            fi_buffer.push_back(append_entry(
+              compressed_buffer,
+              mock.span(),
+              open_viii::CompressionTypeT::lz4));
+          };
+      add_l4z_data(mock1);
+      add_l4z_data(mock2);
+      add_l4z_data(mock3);
+      const auto compressed_temp_file = tl::utility::create_temp_file(
+        "FS_test_Lz4.tmp",
+        std::string_view(
+          std::data(compressed_buffer),
+          std::size(compressed_buffer)));
+      "read entire span"_test = [&compressed_buffer, &fi_buffer] {
+        check_fs2(compressed_buffer, mock1, fi_buffer[0]);
+        check_fs2(compressed_buffer, mock2, fi_buffer[1]);
+        check_fs2(compressed_buffer, mock3, fi_buffer[2]);
+      };
+      "read entire file"_test = [&compressed_temp_file, &fi_buffer] {
+        expect(compressed_temp_file.has_value());
+        expect(std::filesystem::exists(compressed_temp_file.value()));
+        check_fs2(compressed_temp_file.value(), mock1, fi_buffer[0]);
+        check_fs2(compressed_temp_file.value(), mock2, fi_buffer[1]);
+        check_fs2(compressed_temp_file.value(), mock3, fi_buffer[2]);
+      };
+    }
+    {
+      // write compressed L4Z data to buffer stream
+      std::vector<FI> fi_buffer{};
+      fi_buffer.reserve(3);
+      std::stringstream compressed_buffer{};
+      const auto        add_l4z_data
+        = [&compressed_buffer, &fi_buffer](const mock_span_data &mock) {
+            fi_buffer.push_back(append_entry(
+              compressed_buffer,
+              mock.span(),
+              open_viii::CompressionTypeT::lz4));
+          };
+      add_l4z_data(mock1);
+      add_l4z_data(mock2);
+      add_l4z_data(mock3);
+      std::string string_buffer = compressed_buffer.str();
+      "read entire span"_test   = [&string_buffer, &fi_buffer] {
+        check_fs2(string_buffer, mock1, fi_buffer[0]);
+        check_fs2(string_buffer, mock2, fi_buffer[1]);
+        check_fs2(string_buffer, mock3, fi_buffer[2]);
+      };
+    }
+    {
+      // write compressed LZSS data to buffer stream
+      std::vector<FI> fi_buffer{};
+      fi_buffer.reserve(3);
+      std::stringstream compressed_buffer{};
+      const auto        add_lzss_data
+        = [&compressed_buffer, &fi_buffer](const mock_span_data &mock) {
+            fi_buffer.push_back(append_entry(
+              compressed_buffer,
+              mock.span(),
+              open_viii::CompressionTypeT::lzss));
+          };
+      add_lzss_data(mock1);
+      add_lzss_data(mock2);
+      add_lzss_data(mock3);
+      std::string string_buffer = compressed_buffer.str();
+      "read entire span"_test   = [&string_buffer, &fi_buffer] {
+        check_fs2(string_buffer, mock1, fi_buffer[0]);
+        check_fs2(string_buffer, mock2, fi_buffer[1]);
+        check_fs2(string_buffer, mock3, fi_buffer[2]);
+      };
+    }
+    {
+      // write compressed uncompressed data to buffer stream
+      std::vector<FI> fi_buffer{};
+      fi_buffer.reserve(3);
+      std::stringstream compressed_buffer{};
+      const auto        add_uncompressed_data
+        = [&compressed_buffer, &fi_buffer](const mock_span_data &mock) {
+            fi_buffer.push_back(append_entry(
+              compressed_buffer,
+              mock.span(),
+              open_viii::CompressionTypeT::none));
+          };
+      add_uncompressed_data(mock1);
+      add_uncompressed_data(mock2);
+      add_uncompressed_data(mock3);
+      std::string string_buffer = compressed_buffer.str();
+      "read entire span"_test   = [&string_buffer, &fi_buffer] {
+        check_fs2(string_buffer, mock1, fi_buffer[0]);
+        check_fs2(string_buffer, mock2, fi_buffer[1]);
+        check_fs2(string_buffer, mock3, fi_buffer[2]);
+      };
+    }
+    using namespace open_viii;
+    static constexpr std::string_view test_data = "TEST DATA FOR FS";
+    static constexpr mock_span_data   mock(test_data);
+    "FS get_entry uncompressed"_test = [] {
+      std::vector<char> buffer(test_data.begin(), test_data.end());
+      FI   fi(static_cast<uint32_t>(buffer.size()), 0, CompressionTypeT::none);
+      auto result = FS::get_entry(std::span{ buffer }, fi);
+      expect(std::equal(result.begin(), result.end(), test_data.begin()));
     };
-  }
-  {
-    // write compressed LZSS data to buffer
-    std::vector<FI> fi_buffer{};
-    fi_buffer.reserve(3);
-    std::vector<char> compressed_buffer{};
-    const auto        add_lzss_data
-      = [&compressed_buffer, &fi_buffer](const mock_span_data &mock) {
-          fi_buffer.push_back(append_entry(
-            compressed_buffer,
-            mock.span(),
-            open_viii::CompressionTypeT::lzss));
-        };
-    add_lzss_data(mock1);
-    add_lzss_data(mock2);
-    add_lzss_data(mock3);
-    const auto compressed_temp_file = tl::utility::create_temp_file(
-      "FS_test_Lzss.tmp",
-      std::string_view(
-        std::data(compressed_buffer),
-        std::size(compressed_buffer)));
-    "read entire span"_test = [&compressed_buffer, &fi_buffer] {
-      check_fs2(compressed_buffer, mock1, fi_buffer[0]);
-      check_fs2(compressed_buffer, mock2, fi_buffer[1]);
-      check_fs2(compressed_buffer, mock3, fi_buffer[2]);
-    };
-    "read entire file"_test = [&compressed_temp_file, &fi_buffer] {
-      expect(compressed_temp_file.has_value());
-      expect(std::filesystem::exists(compressed_temp_file.value()));
-      check_fs2(compressed_temp_file.value(), mock1, fi_buffer[0]);
-      check_fs2(compressed_temp_file.value(), mock2, fi_buffer[1]);
-      check_fs2(compressed_temp_file.value(), mock3, fi_buffer[2]);
-    };
-  }
-  {
-    // write compressed L4Z data to buffer
-    std::vector<FI> fi_buffer{};
-    fi_buffer.reserve(3);
-    std::vector<char> compressed_buffer{};
-    const auto        add_l4z_data
-      = [&compressed_buffer, &fi_buffer](const mock_span_data &mock) {
-          fi_buffer.push_back(append_entry(
-            compressed_buffer,
-            mock.span(),
-            open_viii::CompressionTypeT::lz4));
-        };
-    add_l4z_data(mock1);
-    add_l4z_data(mock2);
-    add_l4z_data(mock3);
-    const auto compressed_temp_file = tl::utility::create_temp_file(
-      "FS_test_Lz4.tmp",
-      std::string_view(
-        std::data(compressed_buffer),
-        std::size(compressed_buffer)));
-    "read entire span"_test = [&compressed_buffer, &fi_buffer] {
-      check_fs2(compressed_buffer, mock1, fi_buffer[0]);
-      check_fs2(compressed_buffer, mock2, fi_buffer[1]);
-      check_fs2(compressed_buffer, mock3, fi_buffer[2]);
-    };
-    "read entire file"_test = [&compressed_temp_file, &fi_buffer] {
-      expect(compressed_temp_file.has_value());
-      expect(std::filesystem::exists(compressed_temp_file.value()));
-      check_fs2(compressed_temp_file.value(), mock1, fi_buffer[0]);
-      check_fs2(compressed_temp_file.value(), mock2, fi_buffer[1]);
-      check_fs2(compressed_temp_file.value(), mock3, fi_buffer[2]);
-    };
-  }
-  {
-    // write compressed L4Z data to buffer stream
-    std::vector<FI> fi_buffer{};
-    fi_buffer.reserve(3);
-    std::stringstream compressed_buffer{};
-    const auto        add_l4z_data
-      = [&compressed_buffer, &fi_buffer](const mock_span_data &mock) {
-          fi_buffer.push_back(append_entry(
-            compressed_buffer,
-            mock.span(),
-            open_viii::CompressionTypeT::lz4));
-        };
-    add_l4z_data(mock1);
-    add_l4z_data(mock2);
-    add_l4z_data(mock3);
-    std::string string_buffer = compressed_buffer.str();
-    "read entire span"_test   = [&string_buffer, &fi_buffer] {
-      check_fs2(string_buffer, mock1, fi_buffer[0]);
-      check_fs2(string_buffer, mock2, fi_buffer[1]);
-      check_fs2(string_buffer, mock3, fi_buffer[2]);
-    };
-  }
-  {
-    // write compressed LZSS data to buffer stream
-    std::vector<FI> fi_buffer{};
-    fi_buffer.reserve(3);
-    std::stringstream compressed_buffer{};
-    const auto        add_lzss_data
-      = [&compressed_buffer, &fi_buffer](const mock_span_data &mock) {
-          fi_buffer.push_back(append_entry(
-            compressed_buffer,
-            mock.span(),
-            open_viii::CompressionTypeT::lzss));
-        };
-    add_lzss_data(mock1);
-    add_lzss_data(mock2);
-    add_lzss_data(mock3);
-    std::string string_buffer = compressed_buffer.str();
-    "read entire span"_test   = [&string_buffer, &fi_buffer] {
-      check_fs2(string_buffer, mock1, fi_buffer[0]);
-      check_fs2(string_buffer, mock2, fi_buffer[1]);
-      check_fs2(string_buffer, mock3, fi_buffer[2]);
-    };
-  }
-  {
-    // write compressed uncompressed data to buffer stream
-    std::vector<FI> fi_buffer{};
-    fi_buffer.reserve(3);
-    std::stringstream compressed_buffer{};
-    const auto        add_uncompressed_data
-      = [&compressed_buffer, &fi_buffer](const mock_span_data &mock) {
-          fi_buffer.push_back(append_entry(
-            compressed_buffer,
-            mock.span(),
-            open_viii::CompressionTypeT::none));
-        };
-    add_uncompressed_data(mock1);
-    add_uncompressed_data(mock2);
-    add_uncompressed_data(mock3);
-    std::string string_buffer = compressed_buffer.str();
-    "read entire span"_test   = [&string_buffer, &fi_buffer] {
-      check_fs2(string_buffer, mock1, fi_buffer[0]);
-      check_fs2(string_buffer, mock2, fi_buffer[1]);
-      check_fs2(string_buffer, mock3, fi_buffer[2]);
-    };
-  }
-  using namespace open_viii;
-  static constexpr std::string_view test_data = "TEST DATA FOR FS";
-  static constexpr mock_span_data   mock(test_data);
-  "FS get_entry uncompressed"_test = [] {
-    std::vector<char> buffer(test_data.begin(), test_data.end());
-    FI   fi(static_cast<uint32_t>(buffer.size()), 0, CompressionTypeT::none);
-    auto result = FS::get_entry(std::span{ buffer }, fi);
-    expect(std::equal(result.begin(), result.end(), test_data.begin()));
-  };
 
-  "FS append_entry uncompressed"_test = [] {
-    std::vector<char> output;
-    FI fi = append_entry(output, mock.span(), CompressionTypeT::none);
-    expect(fi.uncompressed_size() == mock.span().size());
-    expect(std::equal(output.begin(), output.end(), mock.span().begin()));
-  };
+    "FS append_entry uncompressed"_test = [] {
+      std::vector<char> output;
+      FI fi = append_entry(output, mock.span(), CompressionTypeT::none);
+      expect(fi.uncompressed_size() == mock.span().size());
+      expect(std::equal(output.begin(), output.end(), mock.span().begin()));
+    };
 
-  "FS append and read LZSS compressed entry"_test = [] {
-    std::vector<char> compressed_output;
-    FI                fi
-      = append_entry(compressed_output, mock.span(), CompressionTypeT::lzss);
-    auto decompressed = FS::get_entry(std::span{ compressed_output }, fi);
-    expect(
-      std::equal(
-        decompressed.begin(),
-        decompressed.end(),
-        mock.span().begin()));
-  };
+    "FS append and read LZSS compressed entry"_test = [] {
+      std::vector<char> compressed_output;
+      FI                fi
+        = append_entry(compressed_output, mock.span(), CompressionTypeT::lzss);
+      auto decompressed = FS::get_entry(std::span{ compressed_output }, fi);
+      expect(
+        std::equal(
+          decompressed.begin(),
+          decompressed.end(),
+          mock.span().begin()));
+    };
 
-  "FS append and read L4Z compressed entry"_test = [] {
-    std::vector<char> compressed_output;
-    FI fi = append_entry(compressed_output, mock.span(), CompressionTypeT::lz4);
-    auto decompressed = FS::get_entry(std::span{ compressed_output }, fi);
-    expect(
-      std::equal(
-        decompressed.begin(),
-        decompressed.end(),
-        mock.span().begin()));
-  };
+    "FS append and read L4Z compressed entry"_test = [] {
+      std::vector<char> compressed_output;
+      FI                fi
+        = append_entry(compressed_output, mock.span(), CompressionTypeT::lz4);
+      auto decompressed = FS::get_entry(std::span{ compressed_output }, fi);
+      expect(
+        std::equal(
+          decompressed.begin(),
+          decompressed.end(),
+          mock.span().begin()));
+    };
 
-  "FS read entry from file"_test = [] {
-    const auto    tmp_file = std::filesystem::temp_directory_path() / "test.fs";
-    std::ofstream file(tmp_file, std::ios::binary);
-    file.write(test_data.data(), test_data.size());
-    file.close();
-    FI   fi(static_cast<uint32_t>(test_data.size()), 0, CompressionTypeT::none);
-    auto result = FS::get_entry(tmp_file, fi);
-    expect(std::equal(result.begin(), result.end(), test_data.begin()));
-    std::remove(tmp_file.string().c_str());
+    "FS read entry from file"_test = [] {
+      const auto tmp_file = std::filesystem::temp_directory_path() / "test.fs";
+      std::ofstream file(tmp_file, std::ios::binary);
+      file.write(test_data.data(), test_data.size());
+      file.close();
+      FI fi(static_cast<uint32_t>(test_data.size()), 0, CompressionTypeT::none);
+      auto result = FS::get_entry(tmp_file, fi);
+      expect(std::equal(result.begin(), result.end(), test_data.begin()));
+      std::remove(tmp_file.string().c_str());
+    };
   };
 }

--- a/tests/FileData.cpp
+++ b/tests/FileData.cpp
@@ -29,7 +29,7 @@ static constexpr auto expects = [](
 int
   main()
 {
-  [[maybe_unused]] suite tests = [] {
+  [[maybe_unused]] suite<"FileData"> tests = [] {
     static constexpr std::string_view sample_hex
       = "\x0B\x00\x00\x00\x63\x72\x65\x64\x69\x74\x73\x2E\x61\x76\x69\x2E\xA5"
         "\x0C"

--- a/tests/MapHistory.cpp
+++ b/tests/MapHistory.cpp
@@ -1,0 +1,173 @@
+// MapHistory.cpp
+
+#include "open_viii/graphics/background/MapHistory.hpp"
+#include <boost/ut.hpp>
+#include <fmt/format.h>
+
+int
+  main()
+{
+  using namespace boost::ut;
+  using namespace boost::ut::literals;
+  using namespace boost::ut::operators::terse;
+
+  using namespace open_viii::graphics::background;
+
+  [[maybe_unused]] suite tests = [] {
+    "default constructed MapHistory is empty"_test = [] {
+      const MapHistory history{};
+
+      expect(eq(history.count(), std::size_t{ 0 }));
+      expect(eq(history.redo_count(), std::size_t{ 0 }));
+
+      expect(!history.undo_enabled());
+      expect(!history.redo_enabled());
+    };
+
+    "current undo state is empty when no history exists"_test = [] {
+      const MapHistory history{};
+
+      expect(eq(history.current_undo_pushed(),
+                MapHistory::pushed::unknown));
+
+      expect(history.current_undo_description().empty());
+    };
+
+    "current redo state is empty when no history exists"_test = [] {
+      const MapHistory history{};
+
+      expect(eq(history.current_redo_pushed(),
+                MapHistory::pushed::unknown));
+
+      expect(history.current_redo_description().empty());
+    };
+
+    "copy_working creates undo entry"_test = [] {
+      MapHistory history{};
+
+      (void)history.copy_working("working change");
+
+      expect(eq(history.count(), std::size_t{ 1 }));
+      expect(history.undo_enabled());
+
+      expect(eq(history.current_undo_pushed(),
+                MapHistory::pushed::working));
+
+      expect(eq(history.current_undo_description(),
+                std::string_view{ "working change" }));
+    };
+
+    "copy_original creates undo entry"_test = [] {
+      MapHistory history{};
+
+      (void)history.copy_original("original change");
+
+      expect(eq(history.count(), std::size_t{ 1 }));
+
+      expect(eq(history.current_undo_pushed(),
+                MapHistory::pushed::original));
+
+      expect(eq(history.current_undo_description(),
+                std::string_view{ "original change" }));
+    };
+
+    "undo transfers state to redo history"_test = [] {
+      MapHistory history{};
+
+      (void)history.copy_working("change");
+
+      expect(history.undo());
+
+      expect(eq(history.count(), std::size_t{ 0 }));
+      expect(eq(history.redo_count(), std::size_t{ 1 }));
+
+      expect(history.redo_enabled());
+
+      expect(eq(history.current_redo_description(),
+                std::string_view{ "change" }));
+
+      expect(eq(history.current_redo_pushed(),
+                MapHistory::pushed::working));
+    };
+
+    "redo restores undo history"_test = [] {
+      MapHistory history{};
+
+      (void)history.copy_working("change");
+
+      expect(history.undo());
+      expect(history.redo());
+
+      expect(eq(history.count(), std::size_t{ 1 }));
+      expect(eq(history.redo_count(), std::size_t{ 0 }));
+
+      expect(history.undo_enabled());
+      expect(!history.redo_enabled());
+    };
+
+    "clear_redo removes redo history"_test = [] {
+      MapHistory history{};
+
+      (void)history.copy_working("change");
+
+      expect(history.undo());
+
+      history.clear_redo();
+
+      expect(eq(history.redo_count(), std::size_t{ 0 }));
+      expect(!history.redo_enabled());
+    };
+
+    "begin_multi_frame_working creates single undo entry"_test = [] {
+      MapHistory history{};
+
+      (void)history.begin_multi_frame_working("multi frame");
+
+      (void)history.copy_working("ignored");
+      (void)history.copy_working("ignored");
+
+      history.end_multi_frame_working();
+
+      expect(eq(history.count(), std::size_t{ 1 }));
+
+      expect(eq(history.current_undo_description(),
+                std::string_view{ "multi frame" }));
+    };
+
+    "end_multi_frame_working updates description"_test = [] {
+      MapHistory history{};
+
+      (void)history.begin_multi_frame_working("before");
+
+      history.end_multi_frame_working("after");
+
+      expect(eq(history.current_undo_description(),
+                std::string_view{ "after" }));
+    };
+
+    "undo returns false when history is empty"_test = [] {
+      MapHistory history{};
+
+      expect(!history.undo());
+    };
+
+    "redo returns false when redo history is empty"_test = [] {
+      MapHistory history{};
+
+      expect(!history.redo());
+    };
+
+    "formatter outputs pushed enum names"_test = [] {
+      using namespace std::string_literals;
+
+      expect(eq(fmt::format("{}", MapHistory::pushed::unknown),
+                "Unknown"s));
+
+      expect(eq(fmt::format("{}", MapHistory::pushed::original),
+                "Original"s));
+
+      expect(eq(fmt::format("{}", MapHistory::pushed::working),
+                "Working"s));
+    };
+  };
+}

--- a/tests/MapHistory.cpp
+++ b/tests/MapHistory.cpp
@@ -13,7 +13,7 @@ int
 
   using namespace open_viii::graphics::background;
 
-  [[maybe_unused]] suite tests = [] {
+  [[maybe_unused]] suite<"MapHistory"> tests = [] {
     "default constructed MapHistory is empty"_test = [] {
       const MapHistory history{};
 

--- a/tests/MapHistory.cpp
+++ b/tests/MapHistory.cpp
@@ -27,8 +27,7 @@ int
     "current undo state is empty when no history exists"_test = [] {
       const MapHistory history{};
 
-      expect(eq(history.current_undo_pushed(),
-                MapHistory::pushed::unknown));
+      expect(eq(history.current_undo_pushed(), MapHistory::pushed::unknown));
 
       expect(history.current_undo_description().empty());
     };
@@ -36,8 +35,7 @@ int
     "current redo state is empty when no history exists"_test = [] {
       const MapHistory history{};
 
-      expect(eq(history.current_redo_pushed(),
-                MapHistory::pushed::unknown));
+      expect(eq(history.current_redo_pushed(), MapHistory::pushed::unknown));
 
       expect(history.current_redo_description().empty());
     };
@@ -50,11 +48,11 @@ int
       expect(eq(history.count(), std::size_t{ 1 }));
       expect(history.undo_enabled());
 
-      expect(eq(history.current_undo_pushed(),
-                MapHistory::pushed::working));
+      expect(eq(history.current_undo_pushed(), MapHistory::pushed::working));
 
-      expect(eq(history.current_undo_description(),
-                std::string_view{ "working change" }));
+      expect(eq(
+        history.current_undo_description(),
+        std::string_view{ "working change" }));
     };
 
     "copy_original creates undo entry"_test = [] {
@@ -64,11 +62,11 @@ int
 
       expect(eq(history.count(), std::size_t{ 1 }));
 
-      expect(eq(history.current_undo_pushed(),
-                MapHistory::pushed::original));
+      expect(eq(history.current_undo_pushed(), MapHistory::pushed::original));
 
-      expect(eq(history.current_undo_description(),
-                std::string_view{ "original change" }));
+      expect(eq(
+        history.current_undo_description(),
+        std::string_view{ "original change" }));
     };
 
     "undo transfers state to redo history"_test = [] {
@@ -83,11 +81,10 @@ int
 
       expect(history.redo_enabled());
 
-      expect(eq(history.current_redo_description(),
-                std::string_view{ "change" }));
+      expect(
+        eq(history.current_redo_description(), std::string_view{ "change" }));
 
-      expect(eq(history.current_redo_pushed(),
-                MapHistory::pushed::working));
+      expect(eq(history.current_redo_pushed(), MapHistory::pushed::working));
     };
 
     "redo restores undo history"_test = [] {
@@ -118,7 +115,7 @@ int
       expect(!history.redo_enabled());
     };
 
-    "begin_multi_frame_working creates single undo entry"_test = [] {
+    "begin_multi_frame_working ignores no-op changes"_test = [] {
       MapHistory history{};
 
       (void)history.begin_multi_frame_working("multi frame");
@@ -128,21 +125,8 @@ int
 
       history.end_multi_frame_working();
 
-      expect(eq(history.count(), std::size_t{ 1 }));
-
-      expect(eq(history.current_undo_description(),
-                std::string_view{ "multi frame" }));
-    };
-
-    "end_multi_frame_working updates description"_test = [] {
-      MapHistory history{};
-
-      (void)history.begin_multi_frame_working("before");
-
-      history.end_multi_frame_working("after");
-
-      expect(eq(history.current_undo_description(),
-                std::string_view{ "after" }));
+      expect(eq(history.count(), std::size_t{ 0 }));
+      expect(!history.undo_enabled());
     };
 
     "undo returns false when history is empty"_test = [] {
@@ -160,14 +144,11 @@ int
     "formatter outputs pushed enum names"_test = [] {
       using namespace std::string_literals;
 
-      expect(eq(fmt::format("{}", MapHistory::pushed::unknown),
-                "Unknown"s));
+      expect(eq(fmt::format("{}", MapHistory::pushed::unknown), "Unknown"s));
 
-      expect(eq(fmt::format("{}", MapHistory::pushed::original),
-                "Original"s));
+      expect(eq(fmt::format("{}", MapHistory::pushed::original), "Original"s));
 
-      expect(eq(fmt::format("{}", MapHistory::pushed::working),
-                "Working"s));
+      expect(eq(fmt::format("{}", MapHistory::pushed::working), "Working"s));
     };
   };
 }

--- a/tests/NormalizedSourceTile.cpp
+++ b/tests/NormalizedSourceTile.cpp
@@ -16,7 +16,7 @@ int
 
   using namespace open_viii::graphics::background;
 
-  [[maybe_unused]] suite tests = [] {
+  [[maybe_unused]] suite<"NormalizedSourceTile and NormalizedSourceAnimatedTile"> tests = [] {
     "NormalizedSourceTile default construction"_test = [] {
       NormalizedSourceTile tile{};
 

--- a/tests/PupuID.cpp
+++ b/tests/PupuID.cpp
@@ -16,7 +16,7 @@ int
 
   using namespace open_viii::graphics::background;
 
-  [[maybe_unused]] suite tests = [] {
+  [[maybe_unused]] suite<"PupuID"> tests = [] {
     "PupuID raw constructor"_test = [] {
       constexpr std::uint32_t raw = 0x1234ABCDu;
 

--- a/tests/PupuID.cpp
+++ b/tests/PupuID.cpp
@@ -83,7 +83,7 @@ int
     };
 
     "hsv2rgb produces red"_test = [] {
-      constexpr auto rgb = PupuID::hsv2rgb(0.0f, 1.0f, 1.0f);
+      const auto rgb = PupuID::hsv2rgb(0.0f, 1.0f, 1.0f);
 
       expect(eq(static_cast<int>(rgb[0] * 255.0f), 255));
       expect(eq(static_cast<int>(rgb[1] * 255.0f), 0));
@@ -91,7 +91,7 @@ int
     };
 
     "hsv2rgb produces green"_test = [] {
-      constexpr auto rgb = PupuID::hsv2rgb(1.0f / 3.0f, 1.0f, 1.0f);
+      const auto rgb = PupuID::hsv2rgb(1.0f / 3.0f, 1.0f, 1.0f);
 
       expect(eq(static_cast<int>(rgb[0] * 255.0f), 0));
       expect(eq(static_cast<int>(rgb[1] * 255.0f), 255));
@@ -99,7 +99,7 @@ int
     };
 
     "hsv2rgb produces blue"_test = [] {
-      constexpr auto rgb = PupuID::hsv2rgb(2.0f / 3.0f, 1.0f, 1.0f);
+      const auto rgb = PupuID::hsv2rgb(2.0f / 3.0f, 1.0f, 1.0f);
 
       expect(eq(static_cast<int>(rgb[0] * 255.0f), 0));
       expect(eq(static_cast<int>(rgb[1] * 255.0f), 0));
@@ -111,12 +111,6 @@ int
       expect(eq(PupuID::fract(5.75f), 0.75f));
     };
 
-    "clamp constrains values"_test = [] {
-      expect(eq(PupuID::clamp(-1.0f, 0.0f, 1.0f), 0.0f));
-      expect(eq(PupuID::clamp(0.5f, 0.0f, 1.0f), 0.5f));
-      expect(eq(PupuID::clamp(2.0f, 0.0f, 1.0f), 1.0f));
-    };
-
     "mix interpolates values"_test = [] {
       expect(eq(PupuID::mix(0.0f, 10.0f, 0.0f), 0.0f));
       expect(eq(PupuID::mix(0.0f, 10.0f, 0.5f), 5.0f));
@@ -124,8 +118,8 @@ int
     };
 
     "encode_uint_to_rgba is deterministic"_test = [] {
-      constexpr auto a = PupuID::encode_uint_to_rgba(123u);
-      constexpr auto b = PupuID::encode_uint_to_rgba(123u);
+      const auto a = PupuID::encode_uint_to_rgba(123u);
+      const auto b = PupuID::encode_uint_to_rgba(123u);
 
       expect(eq(a.r(), b.r()));
       expect(eq(a.g(), b.g()));
@@ -134,14 +128,14 @@ int
     };
 
     "encode_uint_to_rgba produces opaque alpha"_test = [] {
-      constexpr auto color = PupuID::encode_uint_to_rgba(42u);
+      const auto color = PupuID::encode_uint_to_rgba(42u);
 
       expect(eq(color.a(), std::uint8_t{ 255u }));
     };
 
     "encode_uint_to_rgba differentiates nearby ids"_test = [] {
-      constexpr auto a     = PupuID::encode_uint_to_rgba(100u);
-      constexpr auto b     = PupuID::encode_uint_to_rgba(101u);
+      const auto a         = PupuID::encode_uint_to_rgba(100u);
+      const auto b         = PupuID::encode_uint_to_rgba(101u);
 
       const bool different = a.r() != b.r() || a.g() != b.g() || a.b() != b.b();
 

--- a/tests/PupuID.cpp
+++ b/tests/PupuID.cpp
@@ -4,6 +4,7 @@
 #include "open_viii/graphics/background/BlendModeT.hpp"
 #include <boost/ut.hpp>
 #include <fmt/format.h>
+#include <limits>
 #include <string>
 
 int
@@ -79,6 +80,72 @@ int
       const PupuID id{ 0x12345678u };
 
       expect(!id.create_summary().empty());
+    };
+
+    "hsv2rgb produces red"_test = [] {
+      constexpr auto rgb = PupuID::hsv2rgb(0.0f, 1.0f, 1.0f);
+
+      expect(eq(static_cast<int>(rgb[0] * 255.0f), 255));
+      expect(eq(static_cast<int>(rgb[1] * 255.0f), 0));
+      expect(eq(static_cast<int>(rgb[2] * 255.0f), 0));
+    };
+
+    "hsv2rgb produces green"_test = [] {
+      constexpr auto rgb = PupuID::hsv2rgb(1.0f / 3.0f, 1.0f, 1.0f);
+
+      expect(eq(static_cast<int>(rgb[0] * 255.0f), 0));
+      expect(eq(static_cast<int>(rgb[1] * 255.0f), 255));
+      expect(eq(static_cast<int>(rgb[2] * 255.0f), 0));
+    };
+
+    "hsv2rgb produces blue"_test = [] {
+      constexpr auto rgb = PupuID::hsv2rgb(2.0f / 3.0f, 1.0f, 1.0f);
+
+      expect(eq(static_cast<int>(rgb[0] * 255.0f), 0));
+      expect(eq(static_cast<int>(rgb[1] * 255.0f), 0));
+      expect(eq(static_cast<int>(rgb[2] * 255.0f), 255));
+    };
+
+    "fract removes integer portion"_test = [] {
+      expect(eq(PupuID::fract(1.25f), 0.25f));
+      expect(eq(PupuID::fract(5.75f), 0.75f));
+    };
+
+    "clamp constrains values"_test = [] {
+      expect(eq(PupuID::clamp(-1.0f, 0.0f, 1.0f), 0.0f));
+      expect(eq(PupuID::clamp(0.5f, 0.0f, 1.0f), 0.5f));
+      expect(eq(PupuID::clamp(2.0f, 0.0f, 1.0f), 1.0f));
+    };
+
+    "mix interpolates values"_test = [] {
+      expect(eq(PupuID::mix(0.0f, 10.0f, 0.0f), 0.0f));
+      expect(eq(PupuID::mix(0.0f, 10.0f, 0.5f), 5.0f));
+      expect(eq(PupuID::mix(0.0f, 10.0f, 1.0f), 10.0f));
+    };
+
+    "encode_uint_to_rgba is deterministic"_test = [] {
+      constexpr auto a = PupuID::encode_uint_to_rgba(123u);
+      constexpr auto b = PupuID::encode_uint_to_rgba(123u);
+
+      expect(eq(a.r(), b.r()));
+      expect(eq(a.g(), b.g()));
+      expect(eq(a.b(), b.b()));
+      expect(eq(a.a(), b.a()));
+    };
+
+    "encode_uint_to_rgba produces opaque alpha"_test = [] {
+      constexpr auto color = PupuID::encode_uint_to_rgba(42u);
+
+      expect(eq(color.a(), std::uint8_t{ 255u }));
+    };
+
+    "encode_uint_to_rgba differentiates nearby ids"_test = [] {
+      constexpr auto a     = PupuID::encode_uint_to_rgba(100u);
+      constexpr auto b     = PupuID::encode_uint_to_rgba(101u);
+
+      const bool different = a.r() != b.r() || a.g() != b.g() || a.b() != b.b();
+
+      expect(different);
     };
   };
 }

--- a/tests/SourceTileConflicts.cpp
+++ b/tests/SourceTileConflicts.cpp
@@ -2,7 +2,7 @@
 
 #include <boost/ut.hpp>
 
-#define UT_source_tile_conflicts_test
+#define UT_SourceTileConflicts_test
 
 #include "open_viii/graphics/background/SourceTileConflicts.hpp"
 #include "open_viii/graphics/background/Tile1.hpp"
@@ -20,22 +20,22 @@ int
   using namespace open_viii::graphics::background;
 
   [[maybe_unused]] suite tests = [] {
-    "source_tile_conflicts default empty state"_test = [] {
-      source_tile_conflicts conflicts{};
+    "SourceTileConflicts default empty state"_test = [] {
+      SourceTileConflicts conflicts{};
 
-      const auto            occupied = conflicts.range_of_occupied_locations()
-                                     | std::ranges::to<std::vector>();
+      const auto          occupied = conflicts.range_of_occupied_locations()
+                                   | std::ranges::to<std::vector>();
 
-      const auto conflict_range      = conflicts.range_of_conflicts_flattened();
+      const auto conflict_range    = conflicts.range_of_conflicts_flattened();
 
       expect(occupied.empty());
       expect(conflict_range.empty());
     };
 
-    "source_tile_conflicts tracks occupied tile"_test = [] {
-      source_tile_conflicts conflicts{};
+    "SourceTileConflicts tracks occupied tile"_test = [] {
+      SourceTileConflicts conflicts{};
 
-      Tile1                 tile{};
+      Tile1               tile{};
 
       tile = tile.with_texture_id(1).with_source_xy(16, 32);
 
@@ -51,10 +51,10 @@ int
       expect(eq(occupied.front().t, 1U));
     };
 
-    "source_tile_conflicts detects conflicts"_test = [] {
-      source_tile_conflicts conflicts{};
+    "SourceTileConflicts detects conflicts"_test = [] {
+      SourceTileConflicts conflicts{};
 
-      Tile1                 tile{};
+      Tile1               tile{};
 
       tile = tile.with_texture_id(2).with_source_xy(32, 48);
 
@@ -68,11 +68,11 @@ int
       expect(eq(flattened[1], 2));
     };
 
-    "source_tile_conflicts separates texture pages"_test = [] {
-      source_tile_conflicts conflicts{};
+    "SourceTileConflicts separates texture pages"_test = [] {
+      SourceTileConflicts conflicts{};
 
-      Tile1                 a{};
-      Tile1                 b{};
+      Tile1               a{};
+      Tile1               b{};
 
       a = a.with_texture_id(0).with_source_xy(16, 16);
 
@@ -91,11 +91,11 @@ int
       expect(eq(occupied.size(), 2U));
     };
 
-    "source_tile_conflicts non conflicts flattened"_test = [] {
-      source_tile_conflicts conflicts{};
+    "SourceTileConflicts non conflicts flattened"_test = [] {
+      SourceTileConflicts conflicts{};
 
-      Tile1                 a{};
-      Tile1                 b{};
+      Tile1               a{};
+      Tile1               b{};
 
       a = a.with_texture_id(0).with_source_xy(0, 0);
 
@@ -112,8 +112,8 @@ int
       expect(eq(non_conflicts[1], 4));
     };
 
-    "source_tile_conflicts operator access by coordinates"_test = [] {
-      source_tile_conflicts conflicts{};
+    "SourceTileConflicts operator access by coordinates"_test = [] {
+      SourceTileConflicts conflicts{};
 
       conflicts(16, 32, 1).push_back(99);
 
@@ -121,10 +121,10 @@ int
       expect(eq(conflicts(16, 32, 1).front(), 99));
     };
 
-    "source_tile_conflicts multiple conflicts stay grouped"_test = [] {
-      source_tile_conflicts conflicts{};
+    "SourceTileConflicts multiple conflicts stay grouped"_test = [] {
+      SourceTileConflicts conflicts{};
 
-      Tile1                 tile{};
+      Tile1               tile{};
 
       tile = tile.with_texture_id(3).with_source_xy(48, 48);
 
@@ -139,10 +139,10 @@ int
       expect(eq(grouped.front().size(), 3U));
     };
 
-    "source_tile_conflicts empty locations shrink after insert"_test = [] {
-      source_tile_conflicts conflicts{};
+    "SourceTileConflicts empty locations shrink after insert"_test = [] {
+      SourceTileConflicts conflicts{};
 
-      const auto            before
+      const auto          before
         = conflicts.range_of_empty_locations() | std::ranges::to<std::vector>();
 
       Tile1 tile{};
@@ -157,15 +157,15 @@ int
       expect(eq(after.size() + 1U, before.size()));
     };
 
-    "source_tile_conflicts calculate/reverse round trip"_test = [] {
-      for (std::uint8_t t = 0; t < source_tile_conflicts::T_SIZE; ++t) {
-        for (std::uint16_t y = 0; y < source_tile_conflicts::GRID_SIZE;
-             y += source_tile_conflicts::Y_SIZE) {
-          for (std::uint16_t x = 0; x < source_tile_conflicts::GRID_SIZE;
-               x += source_tile_conflicts::X_SIZE) {
-            const auto index = source_tile_conflicts::calculate_index(x, y, t);
+    "SourceTileConflicts calculate/reverse round trip"_test = [] {
+      for (std::uint8_t t = 0; t < SourceTileConflicts::T_SIZE; ++t) {
+        for (std::uint16_t y = 0; y < SourceTileConflicts::GRID_SIZE;
+             y += SourceTileConflicts::Y_SIZE) {
+          for (std::uint16_t x = 0; x < SourceTileConflicts::GRID_SIZE;
+               x += SourceTileConflicts::X_SIZE) {
+            const auto index    = SourceTileConflicts::calculate_index(x, y, t);
 
-            const auto location = source_tile_conflicts::reverse_index(index);
+            const auto location = SourceTileConflicts::reverse_index(index);
 
             expect(eq(location.x, x)) << "x mismatch for index " << index;
 
@@ -176,42 +176,40 @@ int
         }
       }
 
-      "source_tile_conflicts calculate_index produces unique indices"_test =
-        [] {
-          constexpr auto total_size = source_tile_conflicts::X_SIZE
-                                    * source_tile_conflicts::Y_SIZE
-                                    * source_tile_conflicts::T_SIZE;
+      "SourceTileConflicts calculate_index produces unique indices"_test = [] {
+        constexpr auto               total_size = SourceTileConflicts::X_SIZE
+                                                * SourceTileConflicts::Y_SIZE
+                                                * SourceTileConflicts::T_SIZE;
 
-          std::array<bool, total_size> seen{};
+        std::array<bool, total_size> seen{};
 
-          std::size_t                  visited_count = 0U;
+        std::size_t                  visited_count = 0U;
 
-          for (std::uint8_t t = 0; t < source_tile_conflicts::T_SIZE; ++t) {
-            for (std::uint16_t y = 0; y < source_tile_conflicts::GRID_SIZE;
-                 y += source_tile_conflicts::Y_SIZE) {
-              for (std::uint16_t x = 0; x < source_tile_conflicts::GRID_SIZE;
-                   x += source_tile_conflicts::X_SIZE) {
-                const auto index
-                  = source_tile_conflicts::calculate_index(x, y, t);
+        for (std::uint8_t t = 0; t < SourceTileConflicts::T_SIZE; ++t) {
+          for (std::uint16_t y = 0; y < SourceTileConflicts::GRID_SIZE;
+               y += SourceTileConflicts::Y_SIZE) {
+            for (std::uint16_t x = 0; x < SourceTileConflicts::GRID_SIZE;
+                 x += SourceTileConflicts::X_SIZE) {
+              const auto index = SourceTileConflicts::calculate_index(x, y, t);
 
-                expect(index < total_size) << "index out of bounds: " << index;
+              expect(index < total_size) << "index out of bounds: " << index;
 
-                expect(!seen[index])
-                  << "duplicate index detected: " << index << " from x=" << x
-                  << " y=" << y << " t=" << static_cast<int>(t);
+              expect(!seen[index])
+                << "duplicate index detected: " << index << " from x=" << x
+                << " y=" << y << " t=" << static_cast<int>(t);
 
-                seen[index] = true;
-                ++visited_count;
-              }
+              seen[index] = true;
+              ++visited_count;
             }
           }
+        }
 
-          expect(eq(visited_count, total_size));
+        expect(eq(visited_count, total_size));
 
-          expect(std::ranges::all_of(seen, [](bool v) {
-            return v;
-          }));
-        };
+        expect(std::ranges::all_of(seen, [](bool v) {
+          return v;
+        }));
+      };
     };
   };
 }

--- a/tests/SourceTileConflicts.cpp
+++ b/tests/SourceTileConflicts.cpp
@@ -19,7 +19,7 @@ int
 
   using namespace open_viii::graphics::background;
 
-  [[maybe_unused]] suite tests = [] {
+  [[maybe_unused]] suite<"SourceTileConflicts"> tests = [] {
     "SourceTileConflicts default empty state"_test = [] {
       SourceTileConflicts conflicts{};
 

--- a/tests/UniquifyPupu.cpp
+++ b/tests/UniquifyPupu.cpp
@@ -14,7 +14,7 @@ int
 
   using namespace open_viii::graphics::background;
 
-  [[maybe_unused]] suite tests = [] {
+  [[maybe_unused]] suite<"UniquifyPupu"> tests = [] {
     "UniquifyPupu increments duplicate ids"_test = [] {
       UniquifyPupu uniquify{};
 

--- a/tests/compression.cpp
+++ b/tests/compression.cpp
@@ -11,7 +11,7 @@ int
   using namespace boost::ut::operators::terse;
   using namespace boost::ut;
   static constexpr tl::utility::sequence<1U, 100U> run{};
-  [[maybe_unused]] suite                           tests = [] {
+  [[maybe_unused]] suite<"Compression"> tests = [] {
     "lzss compress and uncompress"_test = []() {
       const auto run_once = [&]<size_t i>() {
         const auto                  random_char = tl::random::iota<char, i>();


### PR DESCRIPTION
Here’s a cleaned-up and more conventional version of the PR description with tighter structure, reduced repetition, and clearer Markdown formatting. Source: 

---

# Add MapHistory to upstream

## Summary

This PR refactors and expands the `MapHistory`, `PupuID`, and conflict-tracking systems within `open_viii::graphics::background`.

The changes improve API clarity, namespace consistency, deterministic color handling, undo/redo behavior, and test coverage.

---

## Refactors

* Rename `source_tile_conflicts` → `SourceTileConflicts`
* Move `MapHistory` and `PupuID` into the `open_viii::graphics::background` namespace
* Rename normalized tile types to PascalCase variants
* Replace `glm::vec4` color usage with `Color32RGBA`
* Simplify multi-frame working state initialization
* Disable legacy debug history logging scaffolding
* Improve formatting consistency and explicit namespace usage

---

## PupuID Improvements

### Deterministic Color Encoding

Add HSV-based deterministic RGBA color encoding helpers.

### Added Utility Helpers

* `fract`
* `clamp`
* `mix`
* `hsv2rgb`
* `encode_uint_to_rgba`

### Additional Improvements

* Add coverage for HSV conversion and RGBA encoding behavior
* Fix HSV hue scaling behavior
* Add conditional constexpr `<cmath>` support for portability
* Replace custom `clamp` implementation with `std::clamp`

---

## MapHistory Improvements

* Add comprehensive API documentation
* Add PupuID refresh and conflict refresh helpers
* Add working/original conflict accessors
* Add working/original similar-count accessors
* Add color-to-PupuID reverse lookup helpers
* Expose undo/redo history inspection utilities
* Improve no-op multi-frame deduplication behavior
* Simplify multi-frame state initialization logic

---

## Test Improvements

### MapHistory

* Add undo/redo coverage
* Add no-op multi-frame regression coverage
* Add formatter coverage for `MapHistory::pushed`
* Improve assertion readability and formatting consistency

### PupuID

* Add HSV/RGBA utility helper coverage
* Add deterministic RGBA encoding tests
* Improve Boost.UT suite organization and naming consistency

---

## Compatibility

* Gate constexpr `<cmath>` usage behind feature detection
* Improve portability across standard library implementations and MSVC

---

## Notes

This PR also includes general cleanup and consistency improvements across tests, formatting, comments, and namespace qualification.
