### PR TITLE
Extract and generalize background tile operations with expanded test coverage

### DIFF
--- a/applications/src/tile_csv_to_map.cpp
+++ b/applications/src/tile_csv_to_map.cpp
@@ -121,7 +121,7 @@ void
     num.has_value())                                                           \
   tile = tile.with_##arg(*num)
 #define concept_common_code(arg)                                               \
-  if constexpr (has_with_##arg<decltype(tile)>)                                \
+  if constexpr (tile_operations::has_with_##arg<decltype(tile)>)               \
   common_code(arg)
           common_code(z);
           common_code(y);
@@ -137,7 +137,7 @@ void
           concept_common_code(layer_id);
 #undef concept_common_code
 #undef common_code
-          if constexpr (has_with_blend_mode<decltype(tile)>) {
+          if constexpr (tile_operations::has_with_blend_mode<decltype(tile)>) {
             tile = tile.with_blend_mode([](const std::string_view sv) {
               if (open_viii::tools::i_equals(sv, "Half Add"))
                 return BlendModeT::half_add;

--- a/applications/src/tile_csv_to_map.hpp
+++ b/applications/src/tile_csv_to_map.hpp
@@ -5,6 +5,7 @@
 #ifndef OPENVIII_CPP_WIP_TILE_CSV_TO_MAP_HPP
 #define OPENVIII_CPP_WIP_TILE_CSV_TO_MAP_HPP
 #include "open_viii/graphics/background/Map.hpp"
+#include "open_viii/graphics/background/TileOperations.hpp"
 #include <charconv>
 #include <ctre.hpp>
 #include <filesystem>

--- a/src/open_viii/graphics/background/Map.hpp
+++ b/src/open_viii/graphics/background/Map.hpp
@@ -65,6 +65,39 @@ concept is_contiguous_sized_tiles
  && std::ranges::contiguous_range<std::remove_cvref_t<T>>
  && std::ranges::sized_range<std::remove_cvref_t<T>>;
 
+/**
+ * @brief Predicate that filters out sentinel/invalid tiles.
+ *
+ * A tile is considered valid when its x-coordinate does not match the
+ * sentinel end marker value (`0x7FFF`).
+ *
+ * Intended for use with standard algorithms and ranges filters when
+ * iterating tile collections that may contain terminator entries.
+ */
+struct NotInvalidTile
+{
+  /**
+   * @brief Checks whether a tile is valid.
+   *
+   * @tparam T Tile type satisfying the `is_tile` concept.
+   * @param tile Tile instance to evaluate.
+   * @return `true` if the tile is not the sentinel/invalid tile.
+   * @return `false` if the tile x-coordinate equals the sentinel value.
+   */
+  template<is_tile T>
+  constexpr bool
+    operator()(const T &tile) const noexcept
+  {
+    return (std::cmp_not_equal(tile.x(), s_end_x));
+  }
+
+private:
+  /**
+   * @brief Sentinel x-coordinate used to identify invalid/end tiles.
+   */
+  static constexpr std::uint16_t s_end_x = { 0x7FFFU };
+};
+
 struct Map
 {
   using variant_tiles = std::variant<
@@ -83,7 +116,6 @@ private:
   Point<std::int16_t> m_offset{};
 
 public:
-
   /**
    * @brief Resets the map to its default empty state.
    *

--- a/src/open_viii/graphics/background/MapHistory.hpp
+++ b/src/open_viii/graphics/background/MapHistory.hpp
@@ -2,8 +2,8 @@
 // Created by pcvii on 6/2/2022.
 //
 
-#ifndef FIELD_MAP_EDITOR_MAPHISTORY_HPP
-#define FIELD_MAP_EDITOR_MAPHISTORY_HPP
+#ifndef OPEN_VIII_GRAPHICS_BACKGROUND_MAPHISTORY_HPP
+#define OPEN_VIII_GRAPHICS_BACKGROUND_MAPHISTORY_HPP
 #include "Map.hpp"
 #include "NormalizedSourceTile.hpp"
 #include "PupuID.hpp"
@@ -1045,4 +1045,4 @@ inline std::ostream &
 {
   return os << fmt::format("{}", pushed);
 }
-#endif// FIELD_MAP_EDITOR_MAPHISTORY_HPP
+#endif// OPEN_VIII_GRAPHICS_BACKGROUND_MAPHISTORY_HPP

--- a/src/open_viii/graphics/background/PaletteID.hpp
+++ b/src/open_viii/graphics/background/PaletteID.hpp
@@ -50,13 +50,13 @@ public:
       (m_data & THIRTY_INVERSE_MASK) | (in_thirty & THIRTY_MASK));
     return out;
   }
-  [[nodiscard]] std::uint8_t
+  [[nodiscard]] constexpr std::uint8_t
     thirty() const noexcept
   {
     return static_cast<std::uint8_t>(m_data & THIRTY_MASK);
   }
 
-  [[nodiscard]] auto
+  [[nodiscard]] constexpr auto
     with_id(std::uint8_t in_id) const noexcept
   {
     PaletteID out{};
@@ -69,7 +69,7 @@ public:
   {
     return static_cast<std::uint8_t>((m_data & ID_MASK) >> ID_SHIFT);
   }
-  [[nodiscard]] auto
+  [[nodiscard]] constexpr auto
     with_zero(std::uint16_t in_zero) const noexcept
   {
     PaletteID out{};
@@ -77,12 +77,12 @@ public:
       (m_data & ZERO_INVERSE_MASK) | ((in_zero << ZERO_SHIFT) & ZERO_MASK));
     return out;
   }
-  [[nodiscard]] std::uint8_t
+  [[nodiscard]] constexpr std::uint8_t
     zero() const noexcept
   {
     return static_cast<std::uint8_t>((m_data & ZERO_MASK) >> ZERO_SHIFT);
   }
-  [[nodiscard]] explicit
+  [[nodiscard]] constexpr explicit
     operator std::uint16_t() const noexcept
   {
     return m_data;

--- a/src/open_viii/graphics/background/Tile1.hpp
+++ b/src/open_viii/graphics/background/Tile1.hpp
@@ -48,10 +48,6 @@ public:
     operator<=>(const impl_Tile1 &) const = default;
 };
 using Tile1 = TileCommon<impl_Tile1>;
-static_assert(has_with_animation_state<Tile1>);
-static_assert(has_with_animation_id<Tile1>);
-static_assert(has_with_blend_mode<Tile1>);
-static_assert(has_with_layer_id<Tile1>);
 static_assert(sizeof(Tile1) == Tile1::EXPECTED_SIZE);
 }// namespace open_viii::graphics::background
 #endif// VIIIARCHIVE_impl_Tile1_HPP

--- a/src/open_viii/graphics/background/Tile2.hpp
+++ b/src/open_viii/graphics/background/Tile2.hpp
@@ -49,9 +49,5 @@ public:
 };
 using Tile2 = TileCommon<impl_Tile2>;
 static_assert(sizeof(Tile2) == Tile2::EXPECTED_SIZE);
-static_assert(has_with_animation_state<Tile2>);
-static_assert(has_with_animation_id<Tile2>);
-static_assert(not has_with_blend_mode<Tile2>);
-static_assert(not has_with_layer_id<Tile2>);
 }// namespace open_viii::graphics::background
 #endif// VIIIARCHIVE_impl_Tile2_HPP

--- a/src/open_viii/graphics/background/Tile3.hpp
+++ b/src/open_viii/graphics/background/Tile3.hpp
@@ -46,9 +46,5 @@ public:
 };
 using Tile3 = TileCommon<impl_Tile3>;
 static_assert(sizeof(Tile3) == Tile3::EXPECTED_SIZE);
-static_assert(not has_with_animation_state<Tile3>);
-static_assert(not has_with_animation_id<Tile3>);
-static_assert(not has_with_blend_mode<Tile3>);
-static_assert(not has_with_layer_id<Tile3>);
 }// namespace open_viii::graphics::background
 #endif// VIIIARCHIVE_TILE3_HPP

--- a/src/open_viii/graphics/background/TileCommon.hpp
+++ b/src/open_viii/graphics/background/TileCommon.hpp
@@ -354,23 +354,6 @@ public:
     os << std::dec << std::setfill(' ') << std::setw(1) << std::nouppercase;
   }
 };
-template<typename T>
-concept has_with_layer_id
-  = requires(std::decay_t<T> t) { t = t.with_layer_id(1U); };
-
-template<typename T>
-concept has_with_blend_mode = requires(std::decay_t<T> t) {
-  t = t.with_blend_mode(
-    open_viii::graphics::background::BlendModeT::quarter_add);
-};
-
-template<typename T>
-concept has_with_animation_id
-  = requires(std::decay_t<T> t) { t = t.with_animation_id(1U); };
-
-template<typename T>
-concept has_with_animation_state
-  = requires(std::decay_t<T> t) { t = t.with_animation_state(1U); };
 }// namespace open_viii::graphics::background
 
 template<typename tileT>

--- a/src/open_viii/graphics/background/TileOperations.hpp
+++ b/src/open_viii/graphics/background/TileOperations.hpp
@@ -1,0 +1,231 @@
+//
+// Created by pcvii on 6/14/2022.
+//
+
+#ifndef OPEN_VIII_GRAPHICS_BACKGROUND_TILE_OPERATIONS_HPP
+#define OPEN_VIII_GRAPHICS_BACKGROUND_TILE_OPERATIONS_HPP
+#include <open_viii/graphics/background/Map.hpp>
+#include <spdlog/spdlog.h>
+namespace open_viii::graphics::background::tile_operations {
+template<is_tile TileT>
+static constexpr TileT MaxTile = []() {
+  std::array<std::uint8_t, sizeof(TileT)> tmp{};
+  // std::fill(tmp.begin(), tmp.end(), 0xFFU);
+  tmp.fill((std::numeric_limits<std::uint8_t>::max)());
+  return std::bit_cast<TileT>(tmp);
+}();
+#define CONCAT(a, b) a##b
+#define TILE_OPERATION(STRING, FUNCTION)                                       \
+  template<is_tile TileT>                                                      \
+  using CONCAT(STRING, T) = typename std::remove_cvref_t<                      \
+    std::invoke_result_t<decltype(&TileT::FUNCTION), TileT>>;                  \
+  struct STRING                                                                \
+  {                                                                            \
+    template<is_tile TileT>                                                    \
+    constexpr CONCAT(STRING, T)<TileT>                                         \
+      operator()(const TileT &tile) const noexcept                             \
+    {                                                                          \
+      return tile.FUNCTION();                                                  \
+    }                                                                          \
+  };                                                                           \
+  template<typename ValueT>                                                    \
+  struct CONCAT(STRING, Match)                                                 \
+  {                                                                            \
+    template<is_tile TileT>                                                    \
+    constexpr explicit CONCAT(STRING, Match)(TileT tile)                       \
+      : CONCAT(STRING, Match)(tile.FUNCTION())                                 \
+    {}                                                                         \
+    constexpr explicit CONCAT(STRING, Match)(ValueT value)                     \
+      requires(!is_tile<ValueT>)                                               \
+      : m_value(std::move(value))                                              \
+    {}                                                                         \
+    template<is_tile TileT>                                                    \
+    constexpr bool                                                             \
+      operator()(const TileT &tile) const noexcept                             \
+    {                                                                          \
+      return static_cast < CONCAT(STRING, T) < TileT >> (m_value)              \
+          == tile.FUNCTION();                                                  \
+    }                                                                          \
+    auto                                                                       \
+      operator<=>(const CONCAT(STRING, Match) &) const = default;              \
+    bool                                                                       \
+      operator==(const ValueT &that) const                                     \
+    {                                                                          \
+      return m_value == that;                                                  \
+    }                                                                          \
+    std::strong_ordering                                                       \
+      operator<=>(const ValueT &that) const                                    \
+    {                                                                          \
+      return m_value <=> that;                                                 \
+    }                                                                          \
+    template<is_tile TileT>                                                    \
+    bool                                                                       \
+      operator==(const TileT &tile) const                                      \
+    {                                                                          \
+      return static_cast < CONCAT(STRING, T) < TileT >> (m_value)              \
+          == tile.FUNCTION();                                                  \
+    }                                                                          \
+    template<is_tile TileT>                                                    \
+    std::strong_ordering                                                       \
+      operator<=>(const TileT &tile) const                                     \
+    {                                                                          \
+      return static_cast < CONCAT(STRING, T) < TileT                           \
+          >> (m_value) <=> tile.FUNCTION();                                    \
+    }                                                                          \
+                                                                               \
+  private:                                                                     \
+    ValueT m_value = {};                                                       \
+  };                                                                           \
+  template<is_tile TileT>                                                      \
+    CONCAT(STRING, Match)(const TileT &)->CONCAT(STRING, Match)                \
+    < CONCAT(STRING, T) < TileT >> ;                                           \
+  struct CONCAT(STRING, DefaultValue)                                          \
+  {                                                                            \
+    template<is_tile T>                                                        \
+    constexpr CONCAT(STRING, T)<T> operator()(const T &) const noexcept        \
+    {                                                                          \
+      return {};                                                               \
+    }                                                                          \
+  };                                                                           \
+  template<typename TileT>                                                     \
+  concept CONCAT(has_with_, FUNCTION) = requires(                              \
+    std::remove_cvref_t<TileT> tile,                                           \
+    CONCAT(STRING, T) < TileT > value) {                                       \
+    tile = tile.CONCAT(with_, FUNCTION)(value);                                \
+  };                                                                           \
+  template<is_tile TileT>                                                      \
+  struct CONCAT(With, STRING)                                                  \
+  {                                                                            \
+    constexpr explicit CONCAT(With, STRING)(CONCAT(STRING, T) < TileT > value) \
+      : m_value(std::move(value))                                              \
+    {}                                                                         \
+                                                                               \
+    [[nodiscard]] constexpr TileT                                              \
+      operator()(const TileT &tile) const noexcept                             \
+      requires(CONCAT(has_with_, FUNCTION) < TileT >)                          \
+    {                                                                          \
+      spdlog::trace("Used with_" #FUNCTION " to assign: {}", m_value);         \
+      return tile.CONCAT(with_, FUNCTION)(                                     \
+        static_cast < CONCAT(STRING, T) < TileT >> (m_value));                 \
+    }                                                                          \
+    constexpr decltype(auto)                                                   \
+      operator()(const TileT &tile) const noexcept                             \
+      requires(!CONCAT(has_with_, FUNCTION) < TileT >)                         \
+    { /*donno why I can not forward or move when not has_with*/                \
+      spdlog::debug("Has no with_" #FUNCTION);                                 \
+      return tile;                                                             \
+    }                                                                          \
+    friend constexpr TileT                                                     \
+      operator|(const TileT &tile, const CONCAT(With, STRING) & operation)     \
+    {                                                                          \
+      return operation.operator()(tile);                                       \
+    }                                                                          \
+                                                                               \
+  private:                                                                     \
+    CONCAT(STRING, T)<TileT> m_value = {};                                     \
+  };                                                                           \
+  template<is_tile TileT>                                                      \
+  struct CONCAT(TranslateWith, STRING)                                         \
+  {                                                                            \
+    using ValueT = CONCAT(STRING, T)<TileT>;                                   \
+    constexpr explicit CONCAT(TranslateWith, STRING)(                          \
+      const TileT &tile,                                                       \
+      ValueT       to_value)                                                   \
+      : m_to(std::move(to_value)), m_from(tile.FUNCTION())                     \
+    {}                                                                         \
+    constexpr explicit CONCAT(TranslateWith, STRING)(                          \
+      ValueT from_value,                                                       \
+      ValueT to_value)                                                         \
+      : m_to(std::move(to_value)), m_from(std::move(from_value))               \
+    {}                                                                         \
+                                                                               \
+    [[nodiscard]] constexpr TileT                                              \
+      operator()(const TileT &tile) const noexcept                             \
+      requires(CONCAT(has_with_, FUNCTION) < TileT >)                          \
+    {                                                                          \
+      const auto current = m_to + tile.FUNCTION() - m_from;                    \
+      spdlog::trace("Used with_" #FUNCTION " to assign: {}", current);         \
+      return tile.CONCAT(with_, FUNCTION)(static_cast<ValueT>(current));       \
+    }                                                                          \
+                                                                               \
+    constexpr decltype(auto)                                                   \
+      operator()(const TileT &tile) const noexcept                             \
+      requires(!CONCAT(has_with_, FUNCTION) < TileT >)                         \
+    { /*donno why I can not forward or move when not has_with*/                \
+      spdlog::debug("Has no with_" #FUNCTION);                                 \
+      return tile;                                                             \
+    }                                                                          \
+                                                                               \
+  private:                                                                     \
+    ValueT m_to   = {};                                                        \
+    ValueT m_from = {}; /*used to calc offset using original*/                 \
+  };                                                                           \
+  template<is_tile TileT>                                                      \
+  struct CONCAT(STRING, Group)                                                 \
+  {                                                                            \
+    using value_type                  = CONCAT(STRING, T)<TileT>;              \
+    using get                         = STRING;                                \
+    using get_default                 = CONCAT(STRING, DefaultValue);          \
+    constexpr CONCAT(STRING, Group)() = default;                               \
+    constexpr explicit CONCAT(STRING, Group)(value_type value)                 \
+      : current(std::move(value))                                              \
+    {}                                                                         \
+    constexpr explicit CONCAT(STRING, Group)(TileT tile)                       \
+      : current(get{}(tile))                                                   \
+    {}                                                                         \
+    static constexpr value_type min_value = []() -> value_type {               \
+      if constexpr (std::signed_integral<value_type>) {                        \
+        return (std::numeric_limits<value_type>::min)();                       \
+      }                                                                        \
+      else {                                                                   \
+        const auto get_f = get{};                                              \
+        return get_f(TileT{});                                                 \
+      }                                                                        \
+    }();                                                                       \
+    static constexpr value_type max_value = []() -> value_type {               \
+      if constexpr (std::signed_integral<value_type>) {                        \
+        return (std::numeric_limits<value_type>::max)();                       \
+      }                                                                        \
+      else {                                                                   \
+        const auto get_f = get{};                                              \
+        return get_f(MaxTile<TileT>);                                          \
+      }                                                                        \
+    }();                                                                       \
+    value_type            current   = {};                                      \
+    constexpr static bool read_only = !CONCAT(has_with_, FUNCTION)<TileT>;     \
+    using transform_with            = CONCAT(With, STRING)<value_type>;        \
+    using match_with                = CONCAT(STRING, Match)<value_type>;       \
+  }
+
+TILE_OPERATION(X, x);
+TILE_OPERATION(Y, y);
+TILE_OPERATION(XY, xy);
+TILE_OPERATION(Z, z);
+TILE_OPERATION(SourceX, source_x);
+TILE_OPERATION(SourceY, source_y);
+TILE_OPERATION(SourceXY, source_xy);
+TILE_OPERATION(TextureId, texture_id);
+TILE_OPERATION(BlendMode, blend_mode);
+TILE_OPERATION(Blend, blend);
+TILE_OPERATION(Draw, draw);
+TILE_OPERATION(Depth, depth);
+TILE_OPERATION(LayerId, layer_id);
+TILE_OPERATION(PaletteId, palette_id);
+TILE_OPERATION(AnimationId, animation_id);
+TILE_OPERATION(AnimationState, animation_state);
+#undef TILE_OPERATION
+#undef CONCAT
+struct NotInvalidTile
+{
+  template<is_tile T>
+  constexpr bool
+    operator()(const T &tile) const noexcept
+  {
+    return (std::cmp_not_equal(tile.x(), s_end_x));
+  }
+
+private:
+  static constexpr std::uint16_t s_end_x = { 0x7FFFU };
+};
+}// namespace open_viii::graphics::background::tile_operations
+#endif// OPEN_VIII_GRAPHICS_BACKGROUND_TILE_OPERATIONS_HPP

--- a/src/open_viii/graphics/background/TileOperations.hpp
+++ b/src/open_viii/graphics/background/TileOperations.hpp
@@ -215,17 +215,5 @@ TILE_OPERATION(AnimationId, animation_id);
 TILE_OPERATION(AnimationState, animation_state);
 #undef TILE_OPERATION
 #undef CONCAT
-struct NotInvalidTile
-{
-  template<is_tile T>
-  constexpr bool
-    operator()(const T &tile) const noexcept
-  {
-    return (std::cmp_not_equal(tile.x(), s_end_x));
-  }
-
-private:
-  static constexpr std::uint16_t s_end_x = { 0x7FFFU };
-};
 }// namespace open_viii::graphics::background::tile_operations
 #endif// OPEN_VIII_GRAPHICS_BACKGROUND_TILE_OPERATIONS_HPP

--- a/src/open_viii/graphics/background/TileOperations.hpp
+++ b/src/open_viii/graphics/background/TileOperations.hpp
@@ -215,5 +215,20 @@ TILE_OPERATION(AnimationId, animation_id);
 TILE_OPERATION(AnimationState, animation_state);
 #undef TILE_OPERATION
 #undef CONCAT
+
+static_assert(has_with_animation_state<Tile1>);
+static_assert(has_with_animation_id<Tile1>);
+static_assert(has_with_blend_mode<Tile1>);
+static_assert(has_with_layer_id<Tile1>);
+
+static_assert(has_with_animation_state<Tile2>);
+static_assert(has_with_animation_id<Tile2>);
+static_assert(not has_with_blend_mode<Tile2>);
+static_assert(not has_with_layer_id<Tile2>);
+
+static_assert(not has_with_animation_state<Tile3>);
+static_assert(not has_with_animation_id<Tile3>);
+static_assert(not has_with_blend_mode<Tile3>);
+static_assert(not has_with_layer_id<Tile3>);
 }// namespace open_viii::graphics::background::tile_operations
 #endif// OPEN_VIII_GRAPHICS_BACKGROUND_TILE_OPERATIONS_HPP

--- a/src/open_viii/graphics/background/TileOperations.hpp
+++ b/src/open_viii/graphics/background/TileOperations.hpp
@@ -193,7 +193,7 @@ static constexpr TileT MaxTile = []() {
     }();                                                                       \
     value_type            current   = {};                                      \
     constexpr static bool read_only = !CONCAT(has_with_, FUNCTION)<TileT>;     \
-    using transform_with            = CONCAT(With, STRING)<value_type>;        \
+    using transform_with            = CONCAT(With, STRING)<TileT>;             \
     using match_with                = CONCAT(STRING, Match)<value_type>;       \
   }
 

--- a/src/open_viii/graphics/color/CommonColor.hpp
+++ b/src/open_viii/graphics/color/CommonColor.hpp
@@ -7,6 +7,8 @@
 #include "ColorLayoutT.hpp"
 #include "open_viii/Concepts.hpp"
 #include <algorithm>
+#include <fmt/format.h>
+#include <ostream>
 namespace open_viii::graphics {
 template<typename T>
 struct CommonColor : T
@@ -253,4 +255,28 @@ public:
   }
 };
 }// namespace open_viii::graphics
+
+template<typename T>
+struct fmt::formatter<open_viii::graphics::CommonColor<T>>
+{
+  constexpr auto
+    parse(format_parse_context &ctx)
+  {
+    return ctx.begin();
+  }
+
+  template<typename FormatContext>
+  auto
+    format(const open_viii::graphics::CommonColor<T> &color, FormatContext &ctx)
+      const
+  {
+    return fmt::format_to(
+      ctx.out(),
+      "{{{:02X}, {:02X}, {:02X}, {:02X}}}",
+      +color.r(),
+      +color.g(),
+      +color.b(),
+      +color.a());
+  }
+};
 #endif// OPENVIII_CPP_WIP_COMMONCOLOR_HPP

--- a/tests/BackgroundTiles.cpp
+++ b/tests/BackgroundTiles.cpp
@@ -1,6 +1,7 @@
 #include "open_viii/graphics/background/Tile1.hpp"
 #include "open_viii/graphics/background/Tile2.hpp"
 #include "open_viii/graphics/background/Tile3.hpp"
+#include "open_viii/graphics/background/TileOperations.hpp"
 #include <boost/ut.hpp>
 #include <tuple>
 #include <variant>
@@ -67,14 +68,14 @@ int
             {
               using T = decltype(tile);
               using namespace open_viii::graphics::background;
-              if constexpr (has_with_layer_id<T>)
+              if constexpr (tile_operations::has_with_layer_id<T>)
                 tile = tile.with_layer_id(1U);
-              if constexpr (has_with_blend_mode<T>)
+              if constexpr (tile_operations::has_with_blend_mode<T>)
                 tile = tile.with_blend_mode(
                   open_viii::graphics::background::BlendModeT::quarter_add);
-              if constexpr (has_with_animation_id<T>)
+              if constexpr (tile_operations::has_with_animation_id<T>)
                 tile = tile.with_animation_id(1U);
-              if constexpr (has_with_animation_state<T>)
+              if constexpr (tile_operations::has_with_animation_state<T>)
                 tile = tile.with_animation_state(1U);
             }
             expect(eq(tile.source_x(), 1U));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,3 +64,8 @@ add_test_common(MapHistory)
 target_link_libraries(${PROJECT_NAME}_UT_MapHistory
         PRIVATE ${PROJECT_NAME}_VIIIGraphics
 )
+
+add_test_common(TileOperations)
+target_link_libraries(${PROJECT_NAME}_UT_TileOperations
+        PRIVATE ${PROJECT_NAME}_VIIIGraphics
+)

--- a/tests/TileOperations.cpp
+++ b/tests/TileOperations.cpp
@@ -6,127 +6,127 @@
 #include <boost/ut.hpp>
 #include <ranges>
 
-int
-  main()
+using namespace open_viii::graphics::background;
+using namespace open_viii::graphics::background::tile_operations;
+template<is_tile TileT, boost::ut::fixed_string suite_title>
+void
+  run_tile_operations_tests()
 {
   using namespace boost::ut;
   using namespace boost::ut::literals;
   using namespace boost::ut::operators::terse;
 
-  using namespace open_viii::graphics::background;
-  using namespace open_viii::graphics::background::tile_operations;
-
-  [[maybe_unused]] suite<"TileOperations Tile1"> tests1 = [] {
-    "X getter extracts x coordinate Tile1"_test = [] {
-      constexpr auto tile  = Tile1{}.with_x(123);
+  [[maybe_unused]] suite<suite_title> tests1 = [] {
+    "X getter extracts x coordinate"_test = [] {
+      constexpr auto tile  = TileT{}.with_x(123);
 
       constexpr auto value = X{}(tile);
 
       expect(eq(value, 123));
     };
 
-    "Y getter extracts y coordinate Tile1"_test = [] {
-      constexpr auto tile  = Tile1{}.with_y(456);
+    "Y getter extracts y coordinate"_test = [] {
+      constexpr auto tile  = TileT{}.with_y(456);
 
       constexpr auto value = Y{}(tile);
 
       expect(eq(value, 456));
     };
 
-    "XMatch matches tile x Tile1"_test = [] {
-      constexpr auto tile = Tile1{}.with_x(321);
+    "XMatch matches tile x"_test = [] {
+      constexpr auto tile = TileT{}.with_x(321);
 
       expect(XMatch{ 321 }(tile));
       expect(!XMatch{ 111 }(tile));
     };
 
-    "YMatch matches tile y Tile1"_test = [] {
-      constexpr auto tile = Tile1{}.with_y(654);
+    "YMatch matches tile y"_test = [] {
+      constexpr auto tile = TileT{}.with_y(654);
 
       expect(YMatch{ 654 }(tile));
       expect(!YMatch{ 999 }(tile));
     };
 
-    "WithX transforms tile x Tile1"_test = [] {
-      constexpr auto tile    = Tile1{}.with_x(10);
+    "WithX transforms tile x"_test = [] {
+      constexpr auto tile    = TileT{}.with_x(10);
 
-      auto           updated = WithX<Tile1>{ 42 }(tile);
+      auto           updated = WithX<TileT>{ 42 }(tile);
 
       expect(eq(updated.x(), 42));
       expect(eq(updated.y(), tile.y()));
     };
 
-    "WithY transforms tile y Tile1"_test = [] {
-      constexpr auto tile    = Tile1{}.with_y(10);
+    "WithY transforms tile y"_test = [] {
+      constexpr auto tile    = TileT{}.with_y(10);
 
-      auto           updated = WithY<Tile1>{ 77 }(tile);
+      auto           updated = WithY<TileT>{ 77 }(tile);
 
       expect(eq(updated.y(), 77));
       expect(eq(updated.x(), tile.x()));
     };
 
-    "pipe operator applies transform Tile1"_test = [] {
-      constexpr auto tile    = Tile1{}.with_x(1);
+    "pipe operator applies transform"_test = [] {
+      constexpr auto tile    = TileT{}.with_x(1);
 
-      auto           updated = tile | WithX<Tile1>{ 999 };
+      auto           updated = tile | WithX<TileT>{ 999 };
 
       expect(eq(updated.x(), 999));
     };
 
-    "TranslateWithX offsets x coordinate Tile1"_test = [] {
-      constexpr auto tile       = Tile1{}.with_x(100);
+    "TranslateWithX offsets x coordinate"_test = [] {
+      constexpr auto tile       = TileT{}.with_x(100);
 
-      auto           translated = TranslateWithX<Tile1>{ 100, 200 }(tile);
+      auto           translated = TranslateWithX<TileT>{ 100, 200 }(tile);
 
       expect(eq(translated.x(), 200));
     };
 
-    "TranslateWithY offsets y coordinate Tile1"_test = [] {
-      constexpr auto tile       = Tile1{}.with_y(50);
+    "TranslateWithY offsets y coordinate"_test = [] {
+      constexpr auto tile       = TileT{}.with_y(50);
 
-      auto           translated = TranslateWithY<Tile1>{ 50, 75 }(tile);
+      auto           translated = TranslateWithY<TileT>{ 50, 75 }(tile);
 
       expect(eq(translated.y(), 75));
     };
 
-    "NotInvalidTile accepts normal tiles Tile1"_test = [] {
-      constexpr auto tile = Tile1{}.with_x(0);
+    "NotInvalidTile accepts normal tiles"_test = [] {
+      constexpr auto tile = TileT{}.with_x(0);
 
       expect(NotInvalidTile{}(tile));
     };
 
-    "NotInvalidTile rejects sentinel tiles Tile1"_test = [] {
-      constexpr auto tile = Tile1{}.with_x(0x7FFF);
+    "NotInvalidTile rejects sentinel tiles"_test = [] {
+      constexpr auto tile = TileT{}.with_x(0x7FFF);
 
       expect(!NotInvalidTile{}(tile));
     };
 
-    "XGroup stores current value Tile1"_test = [] {
-      constexpr XGroup<Tile1> group{ 123 };
+    "XGroup stores current value"_test = [] {
+      constexpr XGroup<TileT> group{ 123 };
 
       expect(eq(group.current, 123));
     };
 
-    "XGroup constructs from tile Tile1"_test = [] {
-      constexpr auto          tile = Tile1{}.with_x(789);
+    "XGroup constructs from tile"_test = [] {
+      constexpr auto          tile = TileT{}.with_x(789);
 
-      constexpr XGroup<Tile1> group{ tile };
+      constexpr XGroup<TileT> group{ tile };
 
       expect(eq(group.current, 789));
     };
 
-    "XGroup exposes min/max values Tile1"_test = [] {
+    "XGroup exposes min/max values"_test = [] {
       expect(eq(
-        XGroup<Tile1>::min_value,
-        (std::numeric_limits<XGroup<Tile1>::value_type>::min)()));
-      expect(XGroup<Tile1>::max_value >= XGroup<Tile1>::min_value);
+        XGroup<TileT>::min_value,
+        (std::numeric_limits<typename XGroup<TileT>::value_type>::min)()));
+      expect(XGroup<TileT>::max_value >= XGroup<TileT>::min_value);
     };
 
-    "filter invalid tiles with ranges Tile1"_test = [] {
-      constexpr std::array<Tile1, 3> tiles{
-        Tile1{}.with_x(1),
-        Tile1{}.with_x(0x7FFF),
-        Tile1{}.with_x(2),
+    "filter invalid tiles with ranges"_test = [] {
+      constexpr std::array<TileT, 3> tiles{
+        TileT{}.with_x(1),
+        TileT{}.with_x(0x7FFF),
+        TileT{}.with_x(2),
       };
 
       auto filtered = tiles | std::views::filter(NotInvalidTile{});
@@ -138,287 +138,24 @@ int
       expect(eq(it->x(), 2));
     };
 
-    "NotInvalidTile accepts normal tiles Tile1"_test = [] {
-      constexpr auto tile = Tile1{}.with_x(0);
+    "NotInvalidTile accepts normal tiles"_test = [] {
+      constexpr auto tile = TileT{}.with_x(0);
 
       expect(NotInvalidTile{}(tile));
     };
 
-    "NotInvalidTile rejects sentinel tiles Tile1"_test = [] {
-      constexpr auto tile = Tile1{}.with_x(0x7FFF);
+    "NotInvalidTile rejects sentinel tiles"_test = [] {
+      constexpr auto tile = TileT{}.with_x(0x7FFF);
 
       expect(!NotInvalidTile{}(tile));
     };
   };
-
-  [[maybe_unused]] suite<"TileOperations Tile2"> tests2 = [] {
-    "X getter extracts x coordinate Tile2"_test = [] {
-      constexpr auto tile  = Tile2{}.with_x(123);
-
-      constexpr auto value = X{}(tile);
-
-      expect(eq(value, 123));
-    };
-
-    "Y getter extracts y coordinate Tile2"_test = [] {
-      constexpr auto tile  = Tile2{}.with_y(456);
-
-      constexpr auto value = Y{}(tile);
-
-      expect(eq(value, 456));
-    };
-
-    "XMatch matches tile x Tile2"_test = [] {
-      constexpr auto tile = Tile2{}.with_x(321);
-
-      expect(XMatch{ 321 }(tile));
-      expect(!XMatch{ 111 }(tile));
-    };
-
-    "YMatch matches tile y Tile2"_test = [] {
-      constexpr auto tile = Tile2{}.with_y(654);
-
-      expect(YMatch{ 654 }(tile));
-      expect(!YMatch{ 999 }(tile));
-    };
-
-    "WithX transforms tile x Tile2"_test = [] {
-      constexpr auto tile    = Tile2{}.with_x(10);
-
-      auto           updated = WithX<Tile2>{ 42 }(tile);
-
-      expect(eq(updated.x(), 42));
-      expect(eq(updated.y(), tile.y()));
-    };
-
-    "WithY transforms tile y Tile2"_test = [] {
-      constexpr auto tile    = Tile2{}.with_y(10);
-
-      auto           updated = WithY<Tile2>{ 77 }(tile);
-
-      expect(eq(updated.y(), 77));
-      expect(eq(updated.x(), tile.x()));
-    };
-
-    "pipe operator applies transform Tile2"_test = [] {
-      constexpr auto tile    = Tile2{}.with_x(1);
-
-      auto           updated = tile | WithX<Tile2>{ 999 };
-
-      expect(eq(updated.x(), 999));
-    };
-
-    "TranslateWithX offsets x coordinate Tile2"_test = [] {
-      constexpr auto tile       = Tile2{}.with_x(100);
-
-      auto           translated = TranslateWithX<Tile2>{ 100, 200 }(tile);
-
-      expect(eq(translated.x(), 200));
-    };
-
-    "TranslateWithY offsets y coordinate Tile2"_test = [] {
-      constexpr auto tile       = Tile2{}.with_y(50);
-
-      auto           translated = TranslateWithY<Tile2>{ 50, 75 }(tile);
-
-      expect(eq(translated.y(), 75));
-    };
-
-    "NotInvalidTile accepts normal tiles Tile2"_test = [] {
-      constexpr auto tile = Tile2{}.with_x(0);
-
-      expect(NotInvalidTile{}(tile));
-    };
-
-    "NotInvalidTile rejects sentinel tiles Tile2"_test = [] {
-      constexpr auto tile = Tile2{}.with_x(0x7FFF);
-
-      expect(!NotInvalidTile{}(tile));
-    };
-
-    "XGroup stores current value Tile2"_test = [] {
-      constexpr XGroup<Tile2> group{ 123 };
-
-      expect(eq(group.current, 123));
-    };
-
-    "XGroup constructs from tile Tile2"_test = [] {
-      constexpr auto          tile = Tile2{}.with_x(789);
-
-      constexpr XGroup<Tile2> group{ tile };
-
-      expect(eq(group.current, 789));
-    };
-
-    "XGroup exposes min/max values Tile2"_test = [] {
-      expect(eq(
-        XGroup<Tile2>::min_value,
-        (std::numeric_limits<XGroup<Tile2>::value_type>::min)()));
-      expect(XGroup<Tile2>::max_value >= XGroup<Tile2>::min_value);
-    };
-
-    "filter invalid tiles with ranges Tile2"_test = [] {
-      constexpr std::array<Tile2, 3> tiles{
-        Tile2{}.with_x(1),
-        Tile2{}.with_x(0x7FFF),
-        Tile2{}.with_x(2),
-      };
-
-      auto filtered = tiles | std::views::filter(NotInvalidTile{});
-
-      auto it       = filtered.begin();
-
-      expect(eq(it->x(), 1));
-      ++it;
-      expect(eq(it->x(), 2));
-    };
-
-    "NotInvalidTile accepts normal tiles Tile2"_test = [] {
-      constexpr auto tile = Tile2{}.with_x(0);
-
-      expect(NotInvalidTile{}(tile));
-    };
-
-    "NotInvalidTile rejects sentinel tiles Tile2"_test = [] {
-      constexpr auto tile = Tile2{}.with_x(0x7FFF);
-
-      expect(!NotInvalidTile{}(tile));
-    };
-  };
-
-  [[maybe_unused]] suite<"TileOperations Tile3"> tests3 = [] {
-    "X getter extracts x coordinate Tile3"_test = [] {
-      constexpr auto tile  = Tile3{}.with_x(123);
-
-      constexpr auto value = X{}(tile);
-
-      expect(eq(value, 123));
-    };
-
-    "Y getter extracts y coordinate Tile3"_test = [] {
-      constexpr auto tile  = Tile3{}.with_y(456);
-
-      constexpr auto value = Y{}(tile);
-
-      expect(eq(value, 456));
-    };
-
-    "XMatch matches tile x Tile3"_test = [] {
-      constexpr auto tile = Tile3{}.with_x(321);
-
-      expect(XMatch{ 321 }(tile));
-      expect(!XMatch{ 111 }(tile));
-    };
-
-    "YMatch matches tile y Tile3"_test = [] {
-      constexpr auto tile = Tile3{}.with_y(654);
-
-      expect(YMatch{ 654 }(tile));
-      expect(!YMatch{ 999 }(tile));
-    };
-
-    "WithX transforms tile x Tile3"_test = [] {
-      constexpr auto tile    = Tile3{}.with_x(10);
-
-      auto           updated = WithX<Tile3>{ 42 }(tile);
-
-      expect(eq(updated.x(), 42));
-      expect(eq(updated.y(), tile.y()));
-    };
-
-    "WithY transforms tile y Tile3"_test = [] {
-      constexpr auto tile    = Tile3{}.with_y(10);
-
-      auto           updated = WithY<Tile3>{ 77 }(tile);
-
-      expect(eq(updated.y(), 77));
-      expect(eq(updated.x(), tile.x()));
-    };
-
-    "pipe operator applies transform Tile3"_test = [] {
-      constexpr auto tile    = Tile3{}.with_x(1);
-
-      auto           updated = tile | WithX<Tile3>{ 999 };
-
-      expect(eq(updated.x(), 999));
-    };
-
-    "TranslateWithX offsets x coordinate Tile3"_test = [] {
-      constexpr auto tile       = Tile3{}.with_x(100);
-
-      auto           translated = TranslateWithX<Tile3>{ 100, 200 }(tile);
-
-      expect(eq(translated.x(), 200));
-    };
-
-    "TranslateWithY offsets y coordinate Tile3"_test = [] {
-      constexpr auto tile       = Tile3{}.with_y(50);
-
-      auto           translated = TranslateWithY<Tile3>{ 50, 75 }(tile);
-
-      expect(eq(translated.y(), 75));
-    };
-
-    "NotInvalidTile accepts normal tiles Tile3"_test = [] {
-      constexpr auto tile = Tile3{}.with_x(0);
-
-      expect(NotInvalidTile{}(tile));
-    };
-
-    "NotInvalidTile rejects sentinel tiles Tile3"_test = [] {
-      constexpr auto tile = Tile3{}.with_x(0x7FFF);
-
-      expect(!NotInvalidTile{}(tile));
-    };
-
-    "XGroup stores current value Tile3"_test = [] {
-      constexpr XGroup<Tile3> group{ 123 };
-
-      expect(eq(group.current, 123));
-    };
-
-    "XGroup constructs from tile Tile3"_test = [] {
-      constexpr auto          tile = Tile3{}.with_x(789);
-
-      constexpr XGroup<Tile3> group{ tile };
-
-      expect(eq(group.current, 789));
-    };
-
-    "XGroup exposes min/max values Tile3"_test = [] {
-      expect(eq(
-        XGroup<Tile3>::min_value,
-        (std::numeric_limits<XGroup<Tile3>::value_type>::min)()));
-      expect(XGroup<Tile3>::max_value >= XGroup<Tile3>::min_value);
-    };
-
-    "filter invalid tiles with ranges Tile3"_test = [] {
-      constexpr std::array<Tile3, 3> tiles{
-        Tile3{}.with_x(1),
-        Tile3{}.with_x(0x7FFF),
-        Tile3{}.with_x(2),
-      };
-
-      auto filtered = tiles | std::views::filter(NotInvalidTile{});
-
-      auto it       = filtered.begin();
-
-      expect(eq(it->x(), 1));
-      ++it;
-      expect(eq(it->x(), 2));
-    };
-
-
-    "NotInvalidTile accepts normal tiles Tile3"_test = [] {
-      constexpr auto tile = Tile3{}.with_x(0);
-
-      expect(NotInvalidTile{}(tile));
-    };
-
-    "NotInvalidTile rejects sentinel tiles Tile3"_test = [] {
-      constexpr auto tile = Tile3{}.with_x(0x7FFF);
-
-      expect(!NotInvalidTile{}(tile));
-    };
-  };
+}
+
+int
+  main()
+{
+  run_tile_operations_tests<Tile1, "Tile1 TileOperations">();
+  run_tile_operations_tests<Tile2, "Tile2 TileOperations">();
+  run_tile_operations_tests<Tile3, "Tile3 TileOperations">();
 }

--- a/tests/TileOperations.cpp
+++ b/tests/TileOperations.cpp
@@ -1,0 +1,424 @@
+// TileOperations.cpp
+
+#include "open_viii/graphics/background/TileOperations.hpp"
+#include "open_viii/graphics/background/Map.hpp"
+
+#include <boost/ut.hpp>
+#include <ranges>
+
+int
+  main()
+{
+  using namespace boost::ut;
+  using namespace boost::ut::literals;
+  using namespace boost::ut::operators::terse;
+
+  using namespace open_viii::graphics::background;
+  using namespace open_viii::graphics::background::tile_operations;
+
+  [[maybe_unused]] suite<"TileOperations Tile1"> tests1 = [] {
+    "X getter extracts x coordinate Tile1"_test = [] {
+      constexpr auto tile  = Tile1{}.with_x(123);
+
+      constexpr auto value = X{}(tile);
+
+      expect(eq(value, 123));
+    };
+
+    "Y getter extracts y coordinate Tile1"_test = [] {
+      constexpr auto tile  = Tile1{}.with_y(456);
+
+      constexpr auto value = Y{}(tile);
+
+      expect(eq(value, 456));
+    };
+
+    "XMatch matches tile x Tile1"_test = [] {
+      constexpr auto tile = Tile1{}.with_x(321);
+
+      expect(XMatch{ 321 }(tile));
+      expect(!XMatch{ 111 }(tile));
+    };
+
+    "YMatch matches tile y Tile1"_test = [] {
+      constexpr auto tile = Tile1{}.with_y(654);
+
+      expect(YMatch{ 654 }(tile));
+      expect(!YMatch{ 999 }(tile));
+    };
+
+    "WithX transforms tile x Tile1"_test = [] {
+      constexpr auto tile    = Tile1{}.with_x(10);
+
+      auto           updated = WithX<Tile1>{ 42 }(tile);
+
+      expect(eq(updated.x(), 42));
+      expect(eq(updated.y(), tile.y()));
+    };
+
+    "WithY transforms tile y Tile1"_test = [] {
+      constexpr auto tile    = Tile1{}.with_y(10);
+
+      auto           updated = WithY<Tile1>{ 77 }(tile);
+
+      expect(eq(updated.y(), 77));
+      expect(eq(updated.x(), tile.x()));
+    };
+
+    "pipe operator applies transform Tile1"_test = [] {
+      constexpr auto tile    = Tile1{}.with_x(1);
+
+      auto           updated = tile | WithX<Tile1>{ 999 };
+
+      expect(eq(updated.x(), 999));
+    };
+
+    "TranslateWithX offsets x coordinate Tile1"_test = [] {
+      constexpr auto tile       = Tile1{}.with_x(100);
+
+      auto           translated = TranslateWithX<Tile1>{ 100, 200 }(tile);
+
+      expect(eq(translated.x(), 200));
+    };
+
+    "TranslateWithY offsets y coordinate Tile1"_test = [] {
+      constexpr auto tile       = Tile1{}.with_y(50);
+
+      auto           translated = TranslateWithY<Tile1>{ 50, 75 }(tile);
+
+      expect(eq(translated.y(), 75));
+    };
+
+    "NotInvalidTile accepts normal tiles Tile1"_test = [] {
+      constexpr auto tile = Tile1{}.with_x(0);
+
+      expect(NotInvalidTile{}(tile));
+    };
+
+    "NotInvalidTile rejects sentinel tiles Tile1"_test = [] {
+      constexpr auto tile = Tile1{}.with_x(0x7FFF);
+
+      expect(!NotInvalidTile{}(tile));
+    };
+
+    "XGroup stores current value Tile1"_test = [] {
+      constexpr XGroup<Tile1> group{ 123 };
+
+      expect(eq(group.current, 123));
+    };
+
+    "XGroup constructs from tile Tile1"_test = [] {
+      constexpr auto          tile = Tile1{}.with_x(789);
+
+      constexpr XGroup<Tile1> group{ tile };
+
+      expect(eq(group.current, 789));
+    };
+
+    "XGroup exposes min/max values Tile1"_test = [] {
+      expect(eq(
+        XGroup<Tile1>::min_value,
+        (std::numeric_limits<XGroup<Tile1>::value_type>::min)()));
+      expect(XGroup<Tile1>::max_value >= XGroup<Tile1>::min_value);
+    };
+
+    "filter invalid tiles with ranges Tile1"_test = [] {
+      constexpr std::array<Tile1, 3> tiles{
+        Tile1{}.with_x(1),
+        Tile1{}.with_x(0x7FFF),
+        Tile1{}.with_x(2),
+      };
+
+      auto filtered = tiles | std::views::filter(NotInvalidTile{});
+
+      auto it       = filtered.begin();
+
+      expect(eq(it->x(), 1));
+      ++it;
+      expect(eq(it->x(), 2));
+    };
+
+    "NotInvalidTile accepts normal tiles Tile1"_test = [] {
+      constexpr auto tile = Tile1{}.with_x(0);
+
+      expect(NotInvalidTile{}(tile));
+    };
+
+    "NotInvalidTile rejects sentinel tiles Tile1"_test = [] {
+      constexpr auto tile = Tile1{}.with_x(0x7FFF);
+
+      expect(!NotInvalidTile{}(tile));
+    };
+  };
+
+  [[maybe_unused]] suite<"TileOperations Tile2"> tests2 = [] {
+    "X getter extracts x coordinate Tile2"_test = [] {
+      constexpr auto tile  = Tile2{}.with_x(123);
+
+      constexpr auto value = X{}(tile);
+
+      expect(eq(value, 123));
+    };
+
+    "Y getter extracts y coordinate Tile2"_test = [] {
+      constexpr auto tile  = Tile2{}.with_y(456);
+
+      constexpr auto value = Y{}(tile);
+
+      expect(eq(value, 456));
+    };
+
+    "XMatch matches tile x Tile2"_test = [] {
+      constexpr auto tile = Tile2{}.with_x(321);
+
+      expect(XMatch{ 321 }(tile));
+      expect(!XMatch{ 111 }(tile));
+    };
+
+    "YMatch matches tile y Tile2"_test = [] {
+      constexpr auto tile = Tile2{}.with_y(654);
+
+      expect(YMatch{ 654 }(tile));
+      expect(!YMatch{ 999 }(tile));
+    };
+
+    "WithX transforms tile x Tile2"_test = [] {
+      constexpr auto tile    = Tile2{}.with_x(10);
+
+      auto           updated = WithX<Tile2>{ 42 }(tile);
+
+      expect(eq(updated.x(), 42));
+      expect(eq(updated.y(), tile.y()));
+    };
+
+    "WithY transforms tile y Tile2"_test = [] {
+      constexpr auto tile    = Tile2{}.with_y(10);
+
+      auto           updated = WithY<Tile2>{ 77 }(tile);
+
+      expect(eq(updated.y(), 77));
+      expect(eq(updated.x(), tile.x()));
+    };
+
+    "pipe operator applies transform Tile2"_test = [] {
+      constexpr auto tile    = Tile2{}.with_x(1);
+
+      auto           updated = tile | WithX<Tile2>{ 999 };
+
+      expect(eq(updated.x(), 999));
+    };
+
+    "TranslateWithX offsets x coordinate Tile2"_test = [] {
+      constexpr auto tile       = Tile2{}.with_x(100);
+
+      auto           translated = TranslateWithX<Tile2>{ 100, 200 }(tile);
+
+      expect(eq(translated.x(), 200));
+    };
+
+    "TranslateWithY offsets y coordinate Tile2"_test = [] {
+      constexpr auto tile       = Tile2{}.with_y(50);
+
+      auto           translated = TranslateWithY<Tile2>{ 50, 75 }(tile);
+
+      expect(eq(translated.y(), 75));
+    };
+
+    "NotInvalidTile accepts normal tiles Tile2"_test = [] {
+      constexpr auto tile = Tile2{}.with_x(0);
+
+      expect(NotInvalidTile{}(tile));
+    };
+
+    "NotInvalidTile rejects sentinel tiles Tile2"_test = [] {
+      constexpr auto tile = Tile2{}.with_x(0x7FFF);
+
+      expect(!NotInvalidTile{}(tile));
+    };
+
+    "XGroup stores current value Tile2"_test = [] {
+      constexpr XGroup<Tile2> group{ 123 };
+
+      expect(eq(group.current, 123));
+    };
+
+    "XGroup constructs from tile Tile2"_test = [] {
+      constexpr auto          tile = Tile2{}.with_x(789);
+
+      constexpr XGroup<Tile2> group{ tile };
+
+      expect(eq(group.current, 789));
+    };
+
+    "XGroup exposes min/max values Tile2"_test = [] {
+      expect(eq(
+        XGroup<Tile2>::min_value,
+        (std::numeric_limits<XGroup<Tile2>::value_type>::min)()));
+      expect(XGroup<Tile2>::max_value >= XGroup<Tile2>::min_value);
+    };
+
+    "filter invalid tiles with ranges Tile2"_test = [] {
+      constexpr std::array<Tile2, 3> tiles{
+        Tile2{}.with_x(1),
+        Tile2{}.with_x(0x7FFF),
+        Tile2{}.with_x(2),
+      };
+
+      auto filtered = tiles | std::views::filter(NotInvalidTile{});
+
+      auto it       = filtered.begin();
+
+      expect(eq(it->x(), 1));
+      ++it;
+      expect(eq(it->x(), 2));
+    };
+
+    "NotInvalidTile accepts normal tiles Tile2"_test = [] {
+      constexpr auto tile = Tile2{}.with_x(0);
+
+      expect(NotInvalidTile{}(tile));
+    };
+
+    "NotInvalidTile rejects sentinel tiles Tile2"_test = [] {
+      constexpr auto tile = Tile2{}.with_x(0x7FFF);
+
+      expect(!NotInvalidTile{}(tile));
+    };
+  };
+
+  [[maybe_unused]] suite<"TileOperations Tile3"> tests3 = [] {
+    "X getter extracts x coordinate Tile3"_test = [] {
+      constexpr auto tile  = Tile3{}.with_x(123);
+
+      constexpr auto value = X{}(tile);
+
+      expect(eq(value, 123));
+    };
+
+    "Y getter extracts y coordinate Tile3"_test = [] {
+      constexpr auto tile  = Tile3{}.with_y(456);
+
+      constexpr auto value = Y{}(tile);
+
+      expect(eq(value, 456));
+    };
+
+    "XMatch matches tile x Tile3"_test = [] {
+      constexpr auto tile = Tile3{}.with_x(321);
+
+      expect(XMatch{ 321 }(tile));
+      expect(!XMatch{ 111 }(tile));
+    };
+
+    "YMatch matches tile y Tile3"_test = [] {
+      constexpr auto tile = Tile3{}.with_y(654);
+
+      expect(YMatch{ 654 }(tile));
+      expect(!YMatch{ 999 }(tile));
+    };
+
+    "WithX transforms tile x Tile3"_test = [] {
+      constexpr auto tile    = Tile3{}.with_x(10);
+
+      auto           updated = WithX<Tile3>{ 42 }(tile);
+
+      expect(eq(updated.x(), 42));
+      expect(eq(updated.y(), tile.y()));
+    };
+
+    "WithY transforms tile y Tile3"_test = [] {
+      constexpr auto tile    = Tile3{}.with_y(10);
+
+      auto           updated = WithY<Tile3>{ 77 }(tile);
+
+      expect(eq(updated.y(), 77));
+      expect(eq(updated.x(), tile.x()));
+    };
+
+    "pipe operator applies transform Tile3"_test = [] {
+      constexpr auto tile    = Tile3{}.with_x(1);
+
+      auto           updated = tile | WithX<Tile3>{ 999 };
+
+      expect(eq(updated.x(), 999));
+    };
+
+    "TranslateWithX offsets x coordinate Tile3"_test = [] {
+      constexpr auto tile       = Tile3{}.with_x(100);
+
+      auto           translated = TranslateWithX<Tile3>{ 100, 200 }(tile);
+
+      expect(eq(translated.x(), 200));
+    };
+
+    "TranslateWithY offsets y coordinate Tile3"_test = [] {
+      constexpr auto tile       = Tile3{}.with_y(50);
+
+      auto           translated = TranslateWithY<Tile3>{ 50, 75 }(tile);
+
+      expect(eq(translated.y(), 75));
+    };
+
+    "NotInvalidTile accepts normal tiles Tile3"_test = [] {
+      constexpr auto tile = Tile3{}.with_x(0);
+
+      expect(NotInvalidTile{}(tile));
+    };
+
+    "NotInvalidTile rejects sentinel tiles Tile3"_test = [] {
+      constexpr auto tile = Tile3{}.with_x(0x7FFF);
+
+      expect(!NotInvalidTile{}(tile));
+    };
+
+    "XGroup stores current value Tile3"_test = [] {
+      constexpr XGroup<Tile3> group{ 123 };
+
+      expect(eq(group.current, 123));
+    };
+
+    "XGroup constructs from tile Tile3"_test = [] {
+      constexpr auto          tile = Tile3{}.with_x(789);
+
+      constexpr XGroup<Tile3> group{ tile };
+
+      expect(eq(group.current, 789));
+    };
+
+    "XGroup exposes min/max values Tile3"_test = [] {
+      expect(eq(
+        XGroup<Tile3>::min_value,
+        (std::numeric_limits<XGroup<Tile3>::value_type>::min)()));
+      expect(XGroup<Tile3>::max_value >= XGroup<Tile3>::min_value);
+    };
+
+    "filter invalid tiles with ranges Tile3"_test = [] {
+      constexpr std::array<Tile3, 3> tiles{
+        Tile3{}.with_x(1),
+        Tile3{}.with_x(0x7FFF),
+        Tile3{}.with_x(2),
+      };
+
+      auto filtered = tiles | std::views::filter(NotInvalidTile{});
+
+      auto it       = filtered.begin();
+
+      expect(eq(it->x(), 1));
+      ++it;
+      expect(eq(it->x(), 2));
+    };
+
+
+    "NotInvalidTile accepts normal tiles Tile3"_test = [] {
+      constexpr auto tile = Tile3{}.with_x(0);
+
+      expect(NotInvalidTile{}(tile));
+    };
+
+    "NotInvalidTile rejects sentinel tiles Tile3"_test = [] {
+      constexpr auto tile = Tile3{}.with_x(0x7FFF);
+
+      expect(!NotInvalidTile{}(tile));
+    };
+  };
+}

--- a/tests/TileOperations.cpp
+++ b/tests/TileOperations.cpp
@@ -50,7 +50,7 @@ void
     "WithX transforms tile x"_test = [] {
       constexpr auto tile    = TileT{}.with_x(10);
 
-      auto           updated = WithX<TileT>{ 42 }(tile);
+      const auto     updated = WithX<TileT>{ 42 }(tile);
 
       expect(eq(updated.x(), 42));
       expect(eq(updated.y(), tile.y()));
@@ -59,7 +59,7 @@ void
     "WithY transforms tile y"_test = [] {
       constexpr auto tile    = TileT{}.with_y(10);
 
-      auto           updated = WithY<TileT>{ 77 }(tile);
+      const auto     updated = WithY<TileT>{ 77 }(tile);
 
       expect(eq(updated.y(), 77));
       expect(eq(updated.x(), tile.x()));
@@ -68,7 +68,7 @@ void
     "pipe operator applies transform"_test = [] {
       constexpr auto tile    = TileT{}.with_x(1);
 
-      auto           updated = tile | WithX<TileT>{ 999 };
+      const auto     updated = tile | WithX<TileT>{ 999 };
 
       expect(eq(updated.x(), 999));
     };
@@ -76,7 +76,7 @@ void
     "TranslateWithX offsets x coordinate"_test = [] {
       constexpr auto tile       = TileT{}.with_x(100);
 
-      auto           translated = TranslateWithX<TileT>{ 100, 200 }(tile);
+      const auto     translated = TranslateWithX<TileT>{ 100, 200 }(tile);
 
       expect(eq(translated.x(), 200));
     };
@@ -84,7 +84,7 @@ void
     "TranslateWithY offsets y coordinate"_test = [] {
       constexpr auto tile       = TileT{}.with_y(50);
 
-      auto           translated = TranslateWithY<TileT>{ 50, 75 }(tile);
+      const auto     translated = TranslateWithY<TileT>{ 50, 75 }(tile);
 
       expect(eq(translated.y(), 75));
     };
@@ -138,17 +138,135 @@ void
       expect(eq(it->x(), 2));
     };
 
-    "NotInvalidTile accepts normal tiles"_test = [] {
-      constexpr auto tile = TileT{}.with_x(0);
+    "XY getter extracts packed coordinates"_test = [] {
+      constexpr auto tile = TileT{}.with_x(12).with_y(34);
 
-      expect(NotInvalidTile{}(tile));
+      const auto     xy   = XY{}(tile);
+
+      expect(eq(xy.x(), 12));
+      expect(eq(xy.y(), 34));
     };
 
-    "NotInvalidTile rejects sentinel tiles"_test = [] {
-      constexpr auto tile = TileT{}.with_x(0x7FFF);
+    "Z getter extracts z value"_test = [] {
+      constexpr auto tile = TileT{}.with_z(55);
 
-      expect(!NotInvalidTile{}(tile));
+      expect(eq(Z{}(tile), 55));
     };
+
+    "SourceX transform updates source x"_test = [] {
+      constexpr auto tile    = TileT{}.with_source_x(10);
+
+      const auto     updated = WithSourceX<TileT>{ 99 }(tile);
+
+      expect(eq(updated.source_x(), 99));
+    };
+
+    "SourceY match compares source y"_test = [] {
+      constexpr auto tile = TileT{}.with_source_y(44);
+
+      expect(SourceYMatch{ 44 }(tile));
+      expect(!SourceYMatch{ 12 }(tile));
+    };
+
+    "SourceXY getter extracts packed source coordinates"_test = [] {
+      constexpr auto tile = TileT{}.with_source_x(7).with_source_y(9);
+
+      const auto     xy   = SourceXY{}(tile);
+
+      expect(eq(xy.x(), 7));
+      expect(eq(xy.y(), 9));
+    };
+
+    "TextureId transform updates texture id"_test = [] {
+      constexpr auto tile    = TileT{}.with_texture_id(1);
+
+      const auto     updated = WithTextureId<TileT>{ 5 }(tile);
+
+      expect(eq(updated.texture_id(), 5));
+    };
+
+    if constexpr (has_with_blend_mode<TileT>) {
+      "BlendMode transform updates blend mode"_test = [] {
+        using blend_mode_type = tile_operations::BlendModeT<TileT>;
+
+        constexpr auto tile   = TileT{}.with_blend_mode(blend_mode_type::add);
+
+        const auto     updated
+          = WithBlendMode<TileT>{ blend_mode_type::quarter_add }(tile);
+
+        expect(eq(updated.blend_mode(), blend_mode_type::quarter_add));
+      };
+    }
+
+    "Blend predicate matches blend flag"_test = [] {
+      constexpr auto tile = TileT{}.with_blend(true);
+
+      expect(BlendMatch{ true }(tile));
+      expect(!BlendMatch{ false }(tile));
+    };
+
+    "Draw transform updates draw flag"_test = [] {
+      constexpr auto tile    = TileT{}.with_draw(false);
+
+      const auto     updated = WithDraw<TileT>{ true }(tile);
+
+      expect(updated.draw());
+    };
+
+    "Depth getter extracts depth"_test = [] {
+      using namespace open_viii::graphics::literals;
+      constexpr auto tile = TileT{}.with_depth(4_bpp);
+
+      expect(eq(Depth{}(tile), 4_bpp));
+    };
+
+    if constexpr (has_with_layer_id<TileT>) {
+      "LayerId transform updates layer id"_test = [] {
+        using layer_id_type    = LayerIdT<TileT>;
+
+        constexpr auto tile    = TileT{}.with_layer_id(layer_id_type{ 1 });
+
+        auto           updated = WithLayerId<TileT>{ layer_id_type{ 9 } }(tile);
+
+        expect(eq(updated.layer_id(), layer_id_type{ 9 }));
+      };
+    }
+
+    if constexpr (has_with_palette_id<TileT>) {
+      "PaletteId transform updates palette id"_test = [] {
+        using value_type       = PaletteIdT<TileT>;
+
+        constexpr auto tile    = TileT{}.with_palette_id(value_type{ 2 });
+
+        const auto     updated = WithPaletteId<TileT>{ value_type{ 7 } }(tile);
+
+        expect(eq(updated.palette_id(), value_type{ 7 }));
+      };
+    }
+
+    if constexpr (has_with_animation_id<TileT>) {
+      "AnimationId transform updates animation id"_test = [] {
+        using value_type    = AnimationIdT<TileT>;
+
+        constexpr auto tile = TileT{}.with_animation_id(value_type{ 3 });
+
+        const auto updated  = WithAnimationId<TileT>{ value_type{ 8 } }(tile);
+
+        expect(eq(updated.animation_id(), value_type{ 8 }));
+      };
+    }
+
+    if constexpr (has_with_animation_state<TileT>) {
+      "AnimationState transform updates animation state"_test = [] {
+        using value_type    = AnimationStateT<TileT>;
+
+        constexpr auto tile = TileT{}.with_animation_state(value_type{ 1 });
+
+        const auto updated = WithAnimationState<TileT>{ value_type{ 4 } }(tile);
+
+        expect(eq(updated.animation_state(), value_type{ 4 }));
+      };
+    }
   };
 }
 


### PR DESCRIPTION
This PR extracts and generalizes tile operation utilities from the field map editor into the shared background graphics layer, adds comprehensive test coverage for generated tile helpers, and improves constexpr support for palette manipulation.

Key changes:

* Added generic tile operation getter/match/transform utilities
* Moved `NotInvalidTile` into `Map.hpp`
* Fixed `transform_with` alias to use tile types correctly
* Refactored tile operation tests into shared templated suites
* Expanded coverage for generated tile operation helpers
* Made `PaletteID` modifiers/accessors constexpr-capable
* Consolidated tile capability concepts into `TileOperations`
* Renamed `MapHistory` include guards to namespaced macros
* Added `fmt::formatter` support for `CommonColor`

The new test coverage now validates:

* transform helpers
* match predicates
* range filtering
* constexpr operation support
* capability-gated tile APIs
* generated helpers across `Tile1`, `Tile2`, and `Tile3`

All tests pass successfully across supported tile variants.
